### PR TITLE
feat: Implement Admin module UI and mock logic

### DIFF
--- a/app/src/main/java/com/example/rooster/admin/AdminDashboardScreen.kt
+++ b/app/src/main/java/com/example/rooster/admin/AdminDashboardScreen.kt
@@ -1,0 +1,90 @@
+package com.example.rooster.admin
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.example.rooster.admin.analytics.AnalyticsDashboardScreen
+import com.example.rooster.admin.contentmoderation.ContentModerationScreen
+import com.example.rooster.admin.featureflags.FeatureFlagScreen
+import com.example.rooster.admin.systemmonitoring.SystemMonitoringScreen
+import com.example.rooster.admin.usermanagement.UserManagementScreen
+
+// --- Navigation Routes ---
+object AdminDestinations {
+    const val DASHBOARD = "admin_dashboard"
+    const val SYSTEM_MONITORING = "admin_system_monitoring"
+    const val USER_MANAGEMENT = "admin_user_management"
+    const val ANALYTICS_DASHBOARD = "admin_analytics_dashboard"
+    const val CONTENT_MODERATION = "admin_content_moderation"
+    const val FEATURE_FLAGS = "admin_feature_flags"
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AdminDashboardScreen(navController: NavController) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Admin Dashboard") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.DarkGray)
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxSize()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            item { AdminDashboardButton(navController, "System Monitoring", AdminDestinations.SYSTEM_MONITORING) }
+            item { AdminDashboardButton(navController, "User Management", AdminDestinations.USER_MANAGEMENT) }
+            item { AdminDashboardButton(navController, "Analytics Dashboard", AdminDestinations.ANALYTICS_DASHBOARD) }
+            item { AdminDashboardButton(navController, "Content Moderation", AdminDestinations.CONTENT_MODERATION) }
+            item { AdminDashboardButton(navController, "Feature Flags", AdminDestinations.FEATURE_FLAGS) }
+        }
+    }
+}
+
+@Composable
+fun AdminDashboardButton(navController: NavController, text: String, route: String) {
+    Button(
+        onClick = { navController.navigate(route) },
+        modifier = Modifier.fillMaxWidth(0.8f).height(50.dp)
+    ) {
+        Text(text)
+    }
+}
+
+@Composable
+fun AdminFeatureNavigator() {
+    val navController = rememberNavController()
+    NavHost(navController = navController, startDestination = AdminDestinations.DASHBOARD) {
+        composable(AdminDestinations.DASHBOARD) { AdminDashboardScreen(navController) }
+        composable(AdminDestinations.SYSTEM_MONITORING) { SystemMonitoringScreen() }
+        composable(AdminDestinations.USER_MANAGEMENT) { UserManagementScreen() }
+        composable(AdminDestinations.ANALYTICS_DASHBOARD) { AnalyticsDashboardScreen() }
+        composable(AdminDestinations.CONTENT_MODERATION) { ContentModerationScreen() }
+        composable(AdminDestinations.FEATURE_FLAGS) { FeatureFlagScreen() }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewAdminDashboardScreen() {
+    MaterialTheme {
+        // Previewing the whole navigator to see dashboard
+        AdminFeatureNavigator()
+    }
+}

--- a/app/src/main/java/com/example/rooster/admin/analytics/AnalyticsDashboardScreen.kt
+++ b/app/src/main/java/com/example/rooster/admin/analytics/AnalyticsDashboardScreen.kt
@@ -1,0 +1,470 @@
+package com.example.rooster.admin.analytics
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import java.text.DecimalFormat
+import java.util.Date
+
+// --- Data Classes ---
+// Using Maps and Any for flexibility, mirroring Python's dictionary structure.
+// For a production app, more specific data classes would be better.
+
+data class KpiData(val metrics: Map<String, Any>)
+data class UserBehaviorData(val metrics: Map<String, Any>)
+data class RevenueTrackingData(val metrics: Map<String, Any>)
+data class SystemPerformanceSummaryData(val metrics: Map<String, Any>)
+data class ContentEngagementData(val metrics: Map<String, Any>)
+data class TimeSeriesDataPoint(val date: String, val value: Number) // For revenue or user counts
+data class TimeSeriesChartData(val name: String, val points: List<TimeSeriesDataPoint>)
+
+
+// --- ViewModel ---
+class AnalyticsDashboardViewModel : ViewModel() {
+    private val _kpis = MutableStateFlow<KpiData?>(null)
+    val kpis: StateFlow<KpiData?> = _kpis
+
+    private val _userBehavior = MutableStateFlow<UserBehaviorData?>(null)
+    val userBehavior: StateFlow<UserBehaviorData?> = _userBehavior
+
+    private val _revenueTracking = MutableStateFlow<RevenueTrackingData?>(null)
+    val revenueTracking: StateFlow<RevenueTrackingData?> = _revenueTracking
+
+    private val _systemPerformance = MutableStateFlow<SystemPerformanceSummaryData?>(null)
+    val systemPerformance: StateFlow<SystemPerformanceSummaryData?> = _systemPerformance
+
+    private val _contentEngagement = MutableStateFlow<ContentEngagementData?>(null)
+    val contentEngagement: StateFlow<ContentEngagementData?> = _contentEngagement
+
+    private val _revenueOverTime = MutableStateFlow<TimeSeriesChartData?>(null)
+    val revenueOverTime: StateFlow<TimeSeriesChartData?> = _revenueOverTime
+
+    private val _newUsersOverTime = MutableStateFlow<TimeSeriesChartData?>(null)
+    val newUsersOverTime: StateFlow<TimeSeriesChartData?> = _newUsersOverTime
+
+    init {
+        loadMockMetrics()
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun loadMockMetrics() {
+        // Mock data similar to Python script
+        _kpis.value = KpiData(mapOf(
+            "total_users" to 15230,
+            "active_users_monthly" to 8500,
+            "active_users_daily" to 1200,
+            "new_signups_last_30_days" to 750,
+            "user_retention_rate" to "65%"
+        ))
+
+        _userBehavior.value = UserBehaviorData(mapOf(
+            "average_session_duration" to "15 minutes",
+            "pages_per_session" to 5.2,
+            "most_visited_feature" to "Veterinary Consultation",
+            "feature_engagement_rate" to mapOf(
+                "Consultations" to "40%",
+                "Marketplace" to "30%",
+                "Educational Content" to "25%",
+                "Forum" to "15%"
+            ),
+            "user_demographics_summary" to mapOf(
+                "top_country" to "USA (60%)",
+                "user_types" to "Farmers (70%), Veterinarians (30%)"
+            )
+        ))
+
+        _revenueTracking.value = RevenueTrackingData(mapOf(
+            "total_revenue_mtd" to 12500.75,
+            "total_revenue_ytd" to 150200.50,
+            "average_revenue_per_user_arpu" to 9.86,
+            "revenue_by_source" to mapOf(
+                "Consultation Fees" to 75000.00,
+                "Marketplace Commissions" to 60200.50,
+                "Subscription Fees" to 15000.00
+            ),
+            "recent_transactions_count_last_24h" to 85
+        ))
+
+        _systemPerformance.value = SystemPerformanceSummaryData(mapOf(
+            "overall_uptime" to "99.98%",
+            "average_api_response_time" to "140ms",
+            "critical_errors_last_24h" to 2
+        ))
+
+        _contentEngagement.value = ContentEngagementData(mapOf(
+            "new_articles_published_last_30d" to 25,
+            "article_views_last_30d" to 15000,
+            "average_time_on_page_articles" to "3 min 45 sec",
+            "most_popular_article_id" to "article_vet_health_basics"
+        ))
+
+        // Mock time series data
+        val today = java.util.Calendar.getInstance()
+        val revenuePoints = (0..29).map { i ->
+            val day = today.clone() as java.util.Calendar
+            day.add(java.util.Calendar.DATE, -i)
+            TimeSeriesDataPoint(
+                date = "${day.get(java.util.Calendar.YEAR)}-${day.get(java.util.Calendar.MONTH) + 1}-${day.get(java.util.Calendar.DAY_OF_MONTH)}",
+                value = (300..800).random().toDouble()
+            )
+        }.reversed()
+        _revenueOverTime.value = TimeSeriesChartData("Revenue Over Time (Daily)", revenuePoints)
+
+        val newUsersPoints = (0..29).map { i ->
+            val day = today.clone() as java.util.Calendar
+            day.add(java.util.Calendar.DATE, -i)
+            TimeSeriesDataPoint(
+                date = "${day.get(java.util.Calendar.YEAR)}-${day.get(java.util.Calendar.MONTH) + 1}-${day.get(java.util.Calendar.DAY_OF_MONTH)}",
+                value = (10..50).random()
+            )
+        }.reversed()
+        _newUsersOverTime.value = TimeSeriesChartData("New Users Over Time (Daily)", newUsersPoints)
+    }
+}
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AnalyticsDashboardScreen(viewModel: AnalyticsDashboardViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val kpis by viewModel.kpis.collectAsState()
+    val userBehavior by viewModel.userBehavior.collectAsState()
+    val revenueTracking by viewModel.revenueTracking.collectAsState()
+    val systemPerformance by viewModel.systemPerformance.collectAsState()
+    val contentEngagement by viewModel.contentEngagement.collectAsState()
+    val revenueOverTime by viewModel.revenueOverTime.collectAsState()
+    val newUsersOverTime by viewModel.newUsersOverTime.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Analytics Dashboard") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Yellow) // Example
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(modifier = Modifier.padding(paddingValues).padding(16.dp)) {
+            kpis?.let { data -> item { AnalyticsSectionCard("Key Performance Indicators", data.metrics) } }
+            userBehavior?.let { data -> item { AnalyticsSectionCard("User Behavior", data.metrics) } }
+            revenueTracking?.let { data -> item { AnalyticsSectionCard("Revenue Tracking", data.metrics) } }
+            systemPerformance?.let { data -> item { AnalyticsSectionCard("System Performance Summary", data.metrics) } }
+            contentEngagement?.let { data -> item { AnalyticsSectionCard("Content Engagement", data.metrics) } }
+
+            revenueOverTime?.let { data -> item { TimeSeriesSection("Revenue Over Last 30 Days (Sample)", data.points) } }
+            newUsersOverTime?.let { data -> item { TimeSeriesSection("New Users Over Last 30 Days (Sample)", data.points) } }
+        }
+    }
+}
+
+@Composable
+fun AnalyticsSectionCard(title: String, metrics: Map<String, Any>) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(title, style = MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(bottom = 8.dp))
+            DisplayMetrics(metrics)
+        }
+    }
+}
+
+@Composable
+fun DisplayMetrics(metrics: Map<String, Any>, indentLevel: Int = 0) {
+    val indent = "  ".repeat(indentLevel)
+    val decimalFormat = DecimalFormat("#,##0.00")
+
+    metrics.forEach { (key, value) ->
+        val displayKey = key.replace("_", " ").replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
+        when (value) {
+            is Map<*, *> -> {
+                Text("$indent$displayKey:")
+                DisplayMetrics(value as Map<String, Any>, indentLevel + 1)
+            }
+            is Double -> Text("$indent$displayKey: $${decimalFormat.format(value)}")
+            is Number -> Text("$indent$displayKey: $value")
+            else -> Text("$indent$displayKey: $value")
+        }
+    }
+}
+
+@Composable
+fun TimeSeriesSection(title: String, dataPoints: List<TimeSeriesDataPoint>) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(title, style = MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(bottom = 8.dp))
+            // Displaying top 5 for brevity, similar to Python's print output
+            dataPoints.take(5).forEach { point ->
+                Text("  Date: ${point.date}, Value: ${point.value}")
+            }
+            if (dataPoints.size > 5) {
+                Text("  ... and more data points")
+            }
+            // Placeholder for chart:
+            // Text("Chart would be displayed here using MPAndroidChart or similar.",
+            //      modifier = Modifier.padding(vertical = 8.dp).fillMaxWidth(),
+            //      textAlign = androidx.compose.ui.text.style.TextAlign.Center)
+        }
+    }
+}
+
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewAnalyticsDashboardScreen() {
+    MaterialTheme {
+        AnalyticsDashboardScreen(viewModel = AnalyticsDashboardViewModel())
+    }
+}
+package com.example.rooster.admin.analytics
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import java.text.DecimalFormat
+import java.util.Date
+
+// --- Data Classes ---
+// Using Maps and Any for flexibility, mirroring Python's dictionary structure.
+// For a production app, more specific data classes would be better.
+
+data class KpiData(val metrics: Map<String, Any>)
+data class UserBehaviorData(val metrics: Map<String, Any>)
+data class RevenueTrackingData(val metrics: Map<String, Any>)
+data class SystemPerformanceSummaryData(val metrics: Map<String, Any>)
+data class ContentEngagementData(val metrics: Map<String, Any>)
+data class TimeSeriesDataPoint(val date: String, val value: Number) // For revenue or user counts
+data class TimeSeriesChartData(val name: String, val points: List<TimeSeriesDataPoint>)
+
+
+// --- ViewModel ---
+class AnalyticsDashboardViewModel : ViewModel() {
+    private val _kpis = MutableStateFlow<KpiData?>(null)
+    val kpis: StateFlow<KpiData?> = _kpis
+
+    private val _userBehavior = MutableStateFlow<UserBehaviorData?>(null)
+    val userBehavior: StateFlow<UserBehaviorData?> = _userBehavior
+
+    private val _revenueTracking = MutableStateFlow<RevenueTrackingData?>(null)
+    val revenueTracking: StateFlow<RevenueTrackingData?> = _revenueTracking
+
+    private val _systemPerformance = MutableStateFlow<SystemPerformanceSummaryData?>(null)
+    val systemPerformance: StateFlow<SystemPerformanceSummaryData?> = _systemPerformance
+
+    private val _contentEngagement = MutableStateFlow<ContentEngagementData?>(null)
+    val contentEngagement: StateFlow<ContentEngagementData?> = _contentEngagement
+
+    private val _revenueOverTime = MutableStateFlow<TimeSeriesChartData?>(null)
+    val revenueOverTime: StateFlow<TimeSeriesChartData?> = _revenueOverTime
+
+    private val _newUsersOverTime = MutableStateFlow<TimeSeriesChartData?>(null)
+    val newUsersOverTime: StateFlow<TimeSeriesChartData?> = _newUsersOverTime
+
+    init {
+        loadMockMetrics()
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun loadMockMetrics() {
+        // Mock data similar to Python script
+        _kpis.value = KpiData(mapOf(
+            "total_users" to 15230,
+            "active_users_monthly" to 8500,
+            "active_users_daily" to 1200,
+            "new_signups_last_30_days" to 750,
+            "user_retention_rate" to "65%"
+        ))
+
+        _userBehavior.value = UserBehaviorData(mapOf(
+            "average_session_duration" to "15 minutes",
+            "pages_per_session" to 5.2,
+            "most_visited_feature" to "Veterinary Consultation",
+            "feature_engagement_rate" to mapOf(
+                "Consultations" to "40%",
+                "Marketplace" to "30%",
+                "Educational Content" to "25%",
+                "Forum" to "15%"
+            ),
+            "user_demographics_summary" to mapOf(
+                "top_country" to "USA (60%)",
+                "user_types" to "Farmers (70%), Veterinarians (30%)"
+            )
+        ))
+
+        _revenueTracking.value = RevenueTrackingData(mapOf(
+            "total_revenue_mtd" to 12500.75,
+            "total_revenue_ytd" to 150200.50,
+            "average_revenue_per_user_arpu" to 9.86,
+            "revenue_by_source" to mapOf(
+                "Consultation Fees" to 75000.00,
+                "Marketplace Commissions" to 60200.50,
+                "Subscription Fees" to 15000.00
+            ),
+            "recent_transactions_count_last_24h" to 85
+        ))
+
+        _systemPerformance.value = SystemPerformanceSummaryData(mapOf(
+            "overall_uptime" to "99.98%",
+            "average_api_response_time" to "140ms",
+            "critical_errors_last_24h" to 2
+        ))
+
+        _contentEngagement.value = ContentEngagementData(mapOf(
+            "new_articles_published_last_30d" to 25,
+            "article_views_last_30d" to 15000,
+            "average_time_on_page_articles" to "3 min 45 sec",
+            "most_popular_article_id" to "article_vet_health_basics"
+        ))
+
+        // Mock time series data
+        val today = java.util.Calendar.getInstance()
+        val revenuePoints = (0..29).map { i ->
+            val day = today.clone() as java.util.Calendar
+            day.add(java.util.Calendar.DATE, -i)
+            TimeSeriesDataPoint(
+                date = "${day.get(java.util.Calendar.YEAR)}-${day.get(java.util.Calendar.MONTH) + 1}-${day.get(java.util.Calendar.DAY_OF_MONTH)}",
+                value = (300..800).random().toDouble()
+            )
+        }.reversed()
+        _revenueOverTime.value = TimeSeriesChartData("Revenue Over Time (Daily)", revenuePoints)
+
+        val newUsersPoints = (0..29).map { i ->
+            val day = today.clone() as java.util.Calendar
+            day.add(java.util.Calendar.DATE, -i)
+            TimeSeriesDataPoint(
+                date = "${day.get(java.util.Calendar.YEAR)}-${day.get(java.util.Calendar.MONTH) + 1}-${day.get(java.util.Calendar.DAY_OF_MONTH)}",
+                value = (10..50).random()
+            )
+        }.reversed()
+        _newUsersOverTime.value = TimeSeriesChartData("New Users Over Time (Daily)", newUsersPoints)
+    }
+}
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AnalyticsDashboardScreen(viewModel: AnalyticsDashboardViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val kpis by viewModel.kpis.collectAsState()
+    val userBehavior by viewModel.userBehavior.collectAsState()
+    val revenueTracking by viewModel.revenueTracking.collectAsState()
+    val systemPerformance by viewModel.systemPerformance.collectAsState()
+    val contentEngagement by viewModel.contentEngagement.collectAsState()
+    val revenueOverTime by viewModel.revenueOverTime.collectAsState()
+    val newUsersOverTime by viewModel.newUsersOverTime.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Analytics Dashboard") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Yellow) // Example
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(modifier = Modifier.padding(paddingValues).padding(16.dp)) {
+            kpis?.let { data -> item { AnalyticsSectionCard("Key Performance Indicators", data.metrics) } }
+            userBehavior?.let { data -> item { AnalyticsSectionCard("User Behavior", data.metrics) } }
+            revenueTracking?.let { data -> item { AnalyticsSectionCard("Revenue Tracking", data.metrics) } }
+            systemPerformance?.let { data -> item { AnalyticsSectionCard("System Performance Summary", data.metrics) } }
+            contentEngagement?.let { data -> item { AnalyticsSectionCard("Content Engagement", data.metrics) } }
+
+            revenueOverTime?.let { data -> item { TimeSeriesSection("Revenue Over Last 30 Days (Sample)", data.points) } }
+            newUsersOverTime?.let { data -> item { TimeSeriesSection("New Users Over Last 30 Days (Sample)", data.points) } }
+        }
+    }
+}
+
+@Composable
+fun AnalyticsSectionCard(title: String, metrics: Map<String, Any>) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(title, style = MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(bottom = 8.dp))
+            DisplayMetrics(metrics)
+        }
+    }
+}
+
+@Composable
+fun DisplayMetrics(metrics: Map<String, Any>, indentLevel: Int = 0) {
+    val indent = "  ".repeat(indentLevel)
+    val decimalFormat = DecimalFormat("#,##0.00")
+
+    metrics.forEach { (key, value) ->
+        val displayKey = key.replace("_", " ").replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
+        when (value) {
+            is Map<*, *> -> {
+                Text("$indent$displayKey:")
+                DisplayMetrics(value as Map<String, Any>, indentLevel + 1)
+            }
+            is Double -> Text("$indent$displayKey: $${decimalFormat.format(value)}")
+            is Number -> Text("$indent$displayKey: $value")
+            else -> Text("$indent$displayKey: $value")
+        }
+    }
+}
+
+@Composable
+fun TimeSeriesSection(title: String, dataPoints: List<TimeSeriesDataPoint>) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(title, style = MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(bottom = 8.dp))
+            // Displaying top 5 for brevity, similar to Python's print output
+            dataPoints.take(5).forEach { point ->
+                Text("  Date: ${point.date}, Value: ${point.value}")
+            }
+            if (dataPoints.size > 5) {
+                Text("  ... and more data points")
+            }
+            // Placeholder for chart:
+            // Text("Chart would be displayed here using MPAndroidChart or similar.",
+            //      modifier = Modifier.padding(vertical = 8.dp).fillMaxWidth(),
+            //      textAlign = androidx.compose.ui.text.style.TextAlign.Center)
+        }
+    }
+}
+
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewAnalyticsDashboardScreen() {
+    MaterialTheme {
+        AnalyticsDashboardScreen(viewModel = AnalyticsDashboardViewModel())
+    }
+}

--- a/app/src/main/java/com/example/rooster/admin/contentmoderation/ContentModerationScreen.kt
+++ b/app/src/main/java/com/example/rooster/admin/contentmoderation/ContentModerationScreen.kt
@@ -1,0 +1,493 @@
+package com.example.rooster.admin.contentmoderation
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+// --- Data Classes ---
+data class ReportedContent(
+    val reportId: String,
+    val contentId: String,
+    val contentType: String,
+    val reporterUserId: String,
+    val reportedUserId: String,
+    val reason: String,
+    val timestamp: Date,
+    var status: String, // pending_review, approved, rejected, action_taken
+    val contentPreview: String,
+    var moderatorNotes: String? = null,
+    var actionTaken: String? = null,
+    var moderatorId: String? = null,
+    var reviewTimestamp: Date? = null
+) {
+    fun getFormattedTimestamp(): String =
+        SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(timestamp)
+
+    fun getFormattedReviewTimestamp(): String? =
+        reviewTimestamp?.let { SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(it) }
+}
+
+// --- ViewModel ---
+class ContentModerationViewModel : ViewModel() {
+    private val _reports = MutableStateFlow<List<ReportedContent>>(emptyList())
+    val reports: StateFlow<List<ReportedContent>> = _reports
+
+    val pendingReports: StateFlow<List<ReportedContent>> = MutableStateFlow(emptyList()) // Derived flow
+
+    init {
+        loadMockContent()
+        // This is a simple way to create a derived flow. For more complex scenarios,
+        // you might use .map or .combine on the original _reports flow.
+        _reports.value.filter { it.status == "pending_review" }.also {
+            (pendingReports as MutableStateFlow).value = it
+        }
+    }
+
+    private fun loadMockContent() {
+        val now = System.currentTimeMillis()
+        _reports.value = listOf(
+            ReportedContent(
+                "report001", "post123", "forum_post", "user002", "user003",
+                "Spam and unsolicited advertising.", Date(now - 3600000), "pending_review",
+                "Check out my amazing new product at spam.com!"
+            ),
+            ReportedContent(
+                "report002", "comment456", "article_comment", "user001", "user004",
+                "Offensive language.", Date(now - 3 * 3600000), "pending_review",
+                "This article is terrible and the author is an idiot."
+            ),
+            ReportedContent(
+                "report003", "listing789", "marketplace_listing", "user003", "user002",
+                "Misleading product description.", Date(now - 24 * 3600000), "action_taken",
+                "Miracle cure for all animal diseases! Guaranteed!",
+                moderatorNotes = "Removed listing due to false claims. Warned user.",
+                actionTaken = "listing_removed", moderatorId = "admin_mod", reviewTimestamp = Date(now - 12 * 3600000)
+            )
+        )
+        updatePendingReports()
+    }
+
+    private fun updatePendingReports() {
+        (pendingReports as MutableStateFlow).value = _reports.value.filter { it.status == "pending_review" }
+    }
+
+    fun reviewContent(reportId: String, action: String, moderatorId: String, notes: String) {
+        _reports.update { currentReports ->
+            currentReports.map { report ->
+                if (report.reportId == reportId) {
+                    report.copy(
+                        status = "action_taken",
+                        actionTaken = action,
+                        moderatorId = moderatorId,
+                        moderatorNotes = notes,
+                        reviewTimestamp = Date()
+                    )
+                } else report
+            }
+        }
+        updatePendingReports()
+    }
+}
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ContentModerationScreen(viewModel: ContentModerationViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val allReports by viewModel.reports.collectAsState()
+    // val pendingReports by viewModel.pendingReports.collectAsState() // Use this if you prefer separate state
+
+    // For this example, we'll filter directly from allReports for simplicity in tabs or sections
+    val pendingReportsList = allReports.filter { it.status == "pending_review" }
+    val reviewedReportsList = allReports.filter { it.status != "pending_review" }
+
+
+    var showDialog by remember { mutableStateOf(false) }
+    var selectedReport by remember { mutableStateOf<ReportedContent?>(null) }
+    var actionNotes by remember { mutableStateOf("") }
+    var actionType by remember { mutableStateOf("") } // e.g. "remove_content", "warn_user"
+
+    val possibleActions = listOf("approve_content", "remove_content", "warn_user", "ban_user", "reject_report")
+
+
+    if (showDialog && selectedReport != null) {
+        AlertDialog(
+            onDismissRequest = { showDialog = false },
+            title = { Text("Review Report: ${selectedReport?.reportId}") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text("Content: \"${selectedReport?.contentPreview}\"", style = MaterialTheme.typography.bodyMedium)
+                    Text("Reason: ${selectedReport?.reason}", style = MaterialTheme.typography.bodySmall)
+                    OutlinedTextField(
+                        value = actionType,
+                        onValueChange = { actionType = it },
+                        label = { Text("Action Type (e.g., remove_content)") }
+                        // Consider a DropdownMenu for predefined actions
+                    )
+                    OutlinedTextField(
+                        value = actionNotes,
+                        onValueChange = { actionNotes = it },
+                        label = { Text("Moderator Notes") },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            },
+            confirmButton = {
+                Button(onClick = {
+                    selectedReport?.let {
+                        viewModel.reviewContent(it.reportId, actionType, "current_admin_user", actionNotes)
+                    }
+                    showDialog = false
+                    actionNotes = ""
+                    actionType = ""
+                }) { Text("Submit Review") }
+            },
+            dismissButton = { Button(onClick = { showDialog = false }) { Text("Cancel") } }
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Content Moderation") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Red) // Example
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(modifier = Modifier.padding(paddingValues).padding(16.dp)) {
+            item {
+                Text("Pending Reports", style = MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(bottom = 8.dp))
+            }
+            if (pendingReportsList.isEmpty()) {
+                item { Text("No pending reports.") }
+            } else {
+                items(pendingReportsList) { report ->
+                    ReportCard(report) {
+                        selectedReport = it
+                        showDialog = true
+                    }
+                }
+            }
+
+            item {
+                Text("Reviewed Reports", style = MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(top = 16.dp, bottom = 8.dp))
+            }
+            if (reviewedReportsList.isEmpty()) {
+                item { Text("No reviewed reports.") }
+            } else {
+                items(reviewedReportsList) { report ->
+                    ReportCard(report, isReviewed = true) {} // No action on click for reviewed for now
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ReportCard(report: ReportedContent, isReviewed: Boolean = false, onReviewClick: (ReportedContent) -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Report ID: ${report.reportId}", style = MaterialTheme.typography.titleMedium)
+            Text("Content ID: ${report.contentId} (${report.contentType})")
+            Text("Preview: \"${report.contentPreview}\"")
+            Text("Reason: ${report.reason}")
+            Text("Reported by: ${report.reporterUserId} against ${report.reportedUserId}")
+            Text("Reported at: ${report.getFormattedTimestamp()}")
+            Text("Status: ${report.status}", color = if (report.status == "pending_review") Color.Blue else Color.DarkGray)
+
+            if (report.status != "pending_review") {
+                Text("Action Taken: ${report.actionTaken ?: "N/A"}")
+                Text("Moderator: ${report.moderatorId ?: "N/A"}")
+                Text("Moderator Notes: ${report.moderatorNotes ?: "N/A"}")
+                report.getFormattedReviewTimestamp()?.let { Text("Reviewed At: $it") }
+            }
+
+            if (!isReviewed && report.status == "pending_review") {
+                Spacer(Modifier.height(8.dp))
+                Button(onClick = { onReviewClick(report) }, modifier = Modifier.align(Alignment.End)) {
+                    Text("Review Report")
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewContentModerationScreen() {
+    MaterialTheme {
+        ContentModerationScreen(viewModel = ContentModerationViewModel())
+    }
+}
+package com.example.rooster.admin.contentmoderation
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import androidx.compose.ui.Alignment
+
+// --- Data Classes ---
+data class ReportedContent(
+    val reportId: String,
+    val contentId: String,
+    val contentType: String,
+    val reporterUserId: String,
+    val reportedUserId: String,
+    val reason: String,
+    val timestamp: Date,
+    var status: String, // pending_review, approved, rejected, action_taken
+    val contentPreview: String,
+    var moderatorNotes: String? = null,
+    var actionTaken: String? = null,
+    var moderatorId: String? = null,
+    var reviewTimestamp: Date? = null
+) {
+    fun getFormattedTimestamp(): String =
+        SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(timestamp)
+
+    fun getFormattedReviewTimestamp(): String? =
+        reviewTimestamp?.let { SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(it) }
+}
+
+// --- ViewModel ---
+class ContentModerationViewModel : ViewModel() {
+    private val _reports = MutableStateFlow<List<ReportedContent>>(emptyList())
+    val reports: StateFlow<List<ReportedContent>> = _reports
+
+    // No need for a separate pendingReports StateFlow if we filter in the Composable or derive it there.
+    // However, if complex logic depended on it, it could be useful.
+    // val pendingReports: StateFlow<List<ReportedContent>> = _reports.map { it.filter { report -> report.status == "pending_review" } }.stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+
+    init {
+        loadMockContent()
+    }
+
+    private fun loadMockContent() {
+        val now = System.currentTimeMillis()
+        _reports.value = listOf(
+            ReportedContent(
+                "report001", "post123", "forum_post", "user002", "user003",
+                "Spam and unsolicited advertising.", Date(now - 3600000), "pending_review",
+                "Check out my amazing new product at spam.com!"
+            ),
+            ReportedContent(
+                "report002", "comment456", "article_comment", "user001", "user004",
+                "Offensive language.", Date(now - 3 * 3600000), "pending_review",
+                "This article is terrible and the author is an idiot."
+            ),
+            ReportedContent(
+                "report003", "listing789", "marketplace_listing", "user003", "user002",
+                "Misleading product description.", Date(now - 24 * 3600000), "action_taken",
+                "Miracle cure for all animal diseases! Guaranteed!",
+                moderatorNotes = "Removed listing due to false claims. Warned user.",
+                actionTaken = "listing_removed", moderatorId = "admin_mod", reviewTimestamp = Date(now - 12 * 3600000)
+            )
+        )
+    }
+
+    fun reviewContent(reportId: String, action: String, moderatorId: String, notes: String) {
+        _reports.update { currentReports ->
+            currentReports.map { report ->
+                if (report.reportId == reportId) {
+                    report.copy(
+                        status = "action_taken",
+                        actionTaken = action,
+                        moderatorId = moderatorId,
+                        moderatorNotes = notes,
+                        reviewTimestamp = Date()
+                    )
+                } else report
+            }
+        }
+    }
+}
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ContentModerationScreen(viewModel: ContentModerationViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val allReports by viewModel.reports.collectAsState()
+
+    val pendingReportsList = allReports.filter { it.status == "pending_review" }
+    val reviewedReportsList = allReports.filter { it.status != "pending_review" }
+
+    var showDialog by remember { mutableStateOf(false) }
+    var selectedReport by remember { mutableStateOf<ReportedContent?>(null) }
+    var actionNotes by remember { mutableStateOf("") }
+    var actionTypeInput by remember { mutableStateOf("") } // For TextField
+    var expanded by remember { mutableStateOf(false) } // For Dropdown
+
+
+    val possibleActions = listOf("approve_content", "remove_content", "warn_user", "ban_user", "reject_report")
+
+
+    if (showDialog && selectedReport != null) {
+        AlertDialog(
+            onDismissRequest = { showDialog = false },
+            title = { Text("Review Report: ${selectedReport?.reportId}") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text("Content: \"${selectedReport?.contentPreview}\"", style = MaterialTheme.typography.bodyMedium)
+                    Text("Reason: ${selectedReport?.reason}", style = MaterialTheme.typography.bodySmall)
+
+                    ExposedDropdownMenuBox(
+                        expanded = expanded,
+                        onExpandedChange = { expanded = !expanded }
+                    ) {
+                        OutlinedTextField(
+                            value = actionTypeInput,
+                            onValueChange = {}, // Not directly changed, selected from dropdown
+                            readOnly = true,
+                            label = { Text("Select Action") },
+                            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                            modifier = Modifier.menuAnchor().fillMaxWidth()
+                        )
+                        ExposedDropdownMenu(
+                            expanded = expanded,
+                            onDismissRequest = { expanded = false }
+                        ) {
+                            possibleActions.forEach { action ->
+                                DropdownMenuItem(
+                                    text = { Text(action) },
+                                    onClick = {
+                                        actionTypeInput = action
+                                        expanded = false
+                                    }
+                                )
+                            }
+                        }
+                    }
+                    OutlinedTextField(
+                        value = actionNotes,
+                        onValueChange = { actionNotes = it },
+                        label = { Text("Moderator Notes") },
+                        modifier = Modifier.fillMaxWidth(),
+                        minLines = 2
+                    )
+                }
+            },
+            confirmButton = {
+                Button(onClick = {
+                    selectedReport?.let {
+                        viewModel.reviewContent(it.reportId, actionTypeInput, "current_admin_user", actionNotes)
+                    }
+                    showDialog = false
+                    actionNotes = ""
+                    actionTypeInput = ""
+                }, enabled = actionTypeInput.isNotBlank()) { Text("Submit Review") }
+            },
+            dismissButton = { Button(onClick = { showDialog = false; actionNotes = ""; actionTypeInput = "" }) { Text("Cancel") } }
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Content Moderation") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Magenta) // Example color
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(modifier = Modifier.padding(paddingValues).padding(16.dp)) {
+            item {
+                Text("Pending Reports", style = MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(bottom = 8.dp))
+            }
+            if (pendingReportsList.isEmpty()) {
+                item { Text("No pending reports.") }
+            } else {
+                items(pendingReportsList) { report ->
+                    ReportCard(report) {
+                        selectedReport = it
+                        actionTypeInput = "" // Reset for new dialog
+                        actionNotes = ""
+                        showDialog = true
+                    }
+                }
+            }
+
+            item {
+                Text("Reviewed Reports", style = MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(top = 16.dp, bottom = 8.dp))
+            }
+            if (reviewedReportsList.isEmpty()) {
+                item { Text("No reviewed reports.") }
+            } else {
+                items(reviewedReportsList) { report ->
+                    ReportCard(report, isReviewed = true) {} // No action on click for reviewed for now
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ReportCard(report: ReportedContent, isReviewed: Boolean = false, onReviewClick: (ReportedContent) -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text("Report ID: ${report.reportId}", style = MaterialTheme.typography.titleSmall)
+            Text("Content ID: ${report.contentId} (${report.contentType})", style = MaterialTheme.typography.bodyMedium)
+            Text("Preview: \"${report.contentPreview}\"", style = MaterialTheme.typography.bodyMedium)
+            Text("Reason: ${report.reason}", style = MaterialTheme.typography.bodyMedium)
+            Text("Reported by: ${report.reporterUserId} against ${report.reportedUserId}", style = MaterialTheme.typography.bodySmall)
+            Text("Reported at: ${report.getFormattedTimestamp()}", style = MaterialTheme.typography.bodySmall)
+            Text("Status: ${report.status}", color = if (report.status == "pending_review") MaterialTheme.colorScheme.primary else Color.DarkGray, style = MaterialTheme.typography.labelMedium)
+
+            if (report.status != "pending_review") {
+                Text("Action Taken: ${report.actionTaken ?: "N/A"}", style = MaterialTheme.typography.bodySmall)
+                Text("Moderator: ${report.moderatorId ?: "N/A"}", style = MaterialTheme.typography.bodySmall)
+                Text("Moderator Notes: ${report.moderatorNotes ?: "N/A"}", style = MaterialTheme.typography.bodySmall)
+                report.getFormattedReviewTimestamp()?.let { Text("Reviewed At: $it", style = MaterialTheme.typography.bodySmall) }
+            }
+
+            if (!isReviewed && report.status == "pending_review") {
+                Spacer(Modifier.height(8.dp))
+                Button(onClick = { onReviewClick(report) }, modifier = Modifier.align(Alignment.End)) {
+                    Text("Review Report")
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewContentModerationScreen() {
+    MaterialTheme {
+        ContentModerationScreen(viewModel = ContentModerationViewModel())
+    }
+}

--- a/app/src/main/java/com/example/rooster/admin/featureflags/FeatureFlagScreen.kt
+++ b/app/src/main/java/com/example/rooster/admin/featureflags/FeatureFlagScreen.kt
@@ -1,0 +1,550 @@
+package com.example.rooster.admin.featureflags
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+// --- Data Classes ---
+data class FeatureFlag(
+    val name: String, // Unique identifier
+    var description: String,
+    var isActive: Boolean,
+    var rolloutPercentage: Int, // 0-100
+    var targetUserSegment: String,
+    val createdAt: Date,
+    var updatedAt: Date,
+    val createdBy: String
+) {
+    private fun formatDate(date: Date): String =
+        SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(date)
+
+    val formattedCreatedAt: String get() = formatDate(createdAt)
+    val formattedUpdatedAt: String get() = formatDate(updatedAt)
+}
+
+// --- ViewModel ---
+class FeatureFlagViewModel : ViewModel() {
+    private val _featureFlags = MutableStateFlow<List<FeatureFlag>>(emptyList())
+    val featureFlags: StateFlow<List<FeatureFlag>> = _featureFlags
+
+    init {
+        loadMockFlags()
+    }
+
+    private fun loadMockFlags() {
+        val now = System.currentTimeMillis()
+        _featureFlags.value = listOf(
+            FeatureFlag("new_telemedicine_interface", "Enable the redesigned telemedicine interface for video consultations.", false, 0, "all", Date(now - 10 * 86400000L), Date(now - 1 * 86400000L), "admin_jane"),
+            FeatureFlag("ai_diagnosis_assistant_beta", "Enable the AI-powered diagnosis assistant (Beta).", true, 10, "veterinarians_approved_beta", Date(now - 30 * 86400000L), Date(now - 5 * 3600000L), "admin_john"),
+            FeatureFlag("marketplace_commission_increase_test", "A/B Test: Increase marketplace commission from 5% to 7% for a subset of new sellers.", true, 5, "new_sellers_last_7_days", Date(now - 3 * 86400000L), Date(now - 1 * 86400000L), "admin_jane"),
+            FeatureFlag("disable_legacy_reporting", "Disable the old reporting system for users who have migrated to the new one.", false, 0, "migrated_users_group_A", Date(now - 5 * 86400000L), Date(now - 5 * 86400000L), "admin_john")
+        )
+    }
+
+    fun createFlag(name: String, description: String, targetSegment: String, createdBy: String) {
+        if (_featureFlags.value.any { it.name == name }) {
+            // Handle error: flag already exists
+            return
+        }
+        val newFlag = FeatureFlag(name, description, false, 0, targetSegment, Date(), Date(), createdBy)
+        _featureFlags.update { it + newFlag }
+    }
+
+    fun updateFlagStatus(name: String, isActive: Boolean) {
+        _featureFlags.update { flags ->
+            flags.map { if (it.name == name) it.copy(isActive = isActive, updatedAt = Date()) else it }
+        }
+    }
+
+    fun updateRolloutPercentage(name: String, percentage: Int) {
+        if (percentage < 0 || percentage > 100) return // Basic validation
+        _featureFlags.update { flags ->
+            flags.map { if (it.name == name) it.copy(rolloutPercentage = percentage, updatedAt = Date()) else it }
+        }
+    }
+
+    fun updateTargetSegment(name: String, segment: String) {
+        _featureFlags.update { flags ->
+            flags.map { if (it.name == name) it.copy(targetUserSegment = segment, updatedAt = Date()) else it }
+        }
+    }
+
+    fun updateDescription(name: String, description: String) {
+        _featureFlags.update { flags ->
+            flags.map { if (it.name == name) it.copy(description = description, updatedAt = Date()) else it }
+        }
+    }
+
+    fun deleteFlag(name: String) {
+        _featureFlags.update { flags -> flags.filterNot { it.name == name } }
+    }
+}
+
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FeatureFlagScreen(viewModel: FeatureFlagViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val flags by viewModel.featureFlags.collectAsState()
+    var showEditDialog by remember { mutableStateOf(false) }
+    var showCreateDialog by remember { mutableStateOf(false) }
+    var currentEditingFlag by remember { mutableStateOf<FeatureFlag?>(null) }
+
+    // State for Create Dialog
+    var newFlagName by remember { mutableStateOf("") }
+    var newFlagDesc by remember { mutableStateOf("") }
+    var newFlagSegment by remember { mutableStateOf("") }
+
+
+    if (showCreateDialog) {
+        AlertDialog(
+            onDismissRequest = { showCreateDialog = false },
+            title = { Text("Create New Feature Flag") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedTextField(value = newFlagName, onValueChange = { newFlagName = it }, label = { Text("Flag Name (ID)") })
+                    OutlinedTextField(value = newFlagDesc, onValueChange = { newFlagDesc = it }, label = { Text("Description") })
+                    OutlinedTextField(value = newFlagSegment, onValueChange = { newFlagSegment = it }, label = { Text("Target Segment") })
+                }
+            },
+            confirmButton = {
+                Button(onClick = {
+                    if (newFlagName.isNotBlank() && newFlagDesc.isNotBlank() && newFlagSegment.isNotBlank()) {
+                        viewModel.createFlag(newFlagName, newFlagDesc, newFlagSegment, "admin_user")
+                        showCreateDialog = false
+                        newFlagName = ""; newFlagDesc = ""; newFlagSegment = ""
+                    }
+                }) { Text("Create") }
+            },
+            dismissButton = { Button(onClick = { showCreateDialog = false }) { Text("Cancel") } }
+        )
+    }
+
+    currentEditingFlag?.let { flag ->
+        if (showEditDialog) {
+            EditFeatureFlagDialog(
+                flag = flag,
+                viewModel = viewModel,
+                onDismiss = { showEditDialog = false }
+            )
+        }
+    }
+
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Feature Flag Management") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Green) // Example
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { showCreateDialog = true }) {
+                Icon(Icons.Filled.Add, "Create new flag")
+            }
+        }
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = Modifier.padding(paddingValues).padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            items(flags) { flag ->
+                FeatureFlagCard(
+                    flag = flag,
+                    onEditClick = {
+                        currentEditingFlag = it
+                        showEditDialog = true
+                    },
+                    onDeleteClick = { viewModel.deleteFlag(it.name) },
+                    onToggleStatus = { viewModel.updateFlagStatus(flag.name, !flag.isActive) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun FeatureFlagCard(
+    flag: FeatureFlag,
+    onEditClick: (FeatureFlag) -> Unit,
+    onDeleteClick: (FeatureFlag) -> Unit,
+    onToggleStatus: () -> Unit
+) {
+    Card(elevation = CardDefaults.cardElevation(defaultElevation = 2.dp), modifier = Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp)) {
+            Text(flag.name, style = MaterialTheme.typography.titleLarge)
+            Text("Description: ${flag.description}", style = MaterialTheme.typography.bodyMedium)
+            Text("Target Segment: ${flag.targetUserSegment}", style = MaterialTheme.typography.bodySmall)
+            Text("Rollout: ${flag.rolloutPercentage}%", style = MaterialTheme.typography.bodySmall)
+            Text("Created By: ${flag.createdBy} at ${flag.formattedCreatedAt}", style = MaterialTheme.typography.bodySmall)
+            Text("Last Updated: ${flag.formattedUpdatedAt}", style = MaterialTheme.typography.bodySmall)
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(top = 8.dp)
+            ) {
+                Text("Active: ")
+                Switch(checked = flag.isActive, onCheckedChange = { onToggleStatus() })
+                Spacer(Modifier.weight(1f))
+                IconButton(onClick = { onEditClick(flag) }) {
+                    Icon(Icons.Filled.Edit, "Edit Flag")
+                }
+                IconButton(onClick = { onDeleteClick(flag) }) {
+                    Icon(Icons.Filled.Delete, "Delete Flag")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun EditFeatureFlagDialog(
+    flag: FeatureFlag,
+    viewModel: FeatureFlagViewModel,
+    onDismiss: () -> Unit
+) {
+    var description by remember { mutableStateOf(flag.description) }
+    var rolloutPercentage by remember { mutableStateOf(flag.rolloutPercentage.toString()) }
+    var targetSegment by remember { mutableStateOf(flag.targetUserSegment) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Edit: ${flag.name}") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(value = description, onValueChange = { description = it }, label = { Text("Description") })
+                OutlinedTextField(
+                    value = rolloutPercentage,
+                    onValueChange = { rolloutPercentage = it.filter { char -> char.isDigit() } },
+                    label = { Text("Rollout % (0-100)") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+                )
+                OutlinedTextField(value = targetSegment, onValueChange = { targetSegment = it }, label = { Text("Target Segment") })
+            }
+        },
+        confirmButton = {
+            Button(onClick = {
+                viewModel.updateDescription(flag.name, description)
+                rolloutPercentage.toIntOrNull()?.let { percent ->
+                     if(percent in 0..100) viewModel.updateRolloutPercentage(flag.name, percent)
+                }
+                viewModel.updateTargetSegment(flag.name, targetSegment)
+                onDismiss()
+            }) { Text("Save Changes") }
+        },
+        dismissButton = { Button(onClick = onDismiss) { Text("Cancel") } }
+    )
+}
+
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewFeatureFlagScreen() {
+    MaterialTheme {
+        FeatureFlagScreen(viewModel = FeatureFlagViewModel())
+    }
+}
+package com.example.rooster.admin.featureflags
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+// --- Data Classes ---
+data class FeatureFlag(
+    val name: String, // Unique identifier
+    var description: String,
+    var isActive: Boolean,
+    var rolloutPercentage: Int, // 0-100
+    var targetUserSegment: String,
+    val createdAt: Date,
+    var updatedAt: Date,
+    val createdBy: String
+) {
+    private fun formatDate(date: Date): String =
+        SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(date)
+
+    val formattedCreatedAt: String get() = formatDate(createdAt)
+    val formattedUpdatedAt: String get() = formatDate(updatedAt)
+}
+
+// --- ViewModel ---
+class FeatureFlagViewModel : ViewModel() {
+    private val _featureFlags = MutableStateFlow<List<FeatureFlag>>(emptyList())
+    val featureFlags: StateFlow<List<FeatureFlag>> = _featureFlags
+
+    init {
+        loadMockFlags()
+    }
+
+    private fun loadMockFlags() {
+        val now = System.currentTimeMillis()
+        _featureFlags.value = listOf(
+            FeatureFlag("new_telemedicine_interface", "Enable the redesigned telemedicine interface for video consultations.", false, 0, "all", Date(now - 10 * 86400000L), Date(now - 1 * 86400000L), "admin_jane"),
+            FeatureFlag("ai_diagnosis_assistant_beta", "Enable the AI-powered diagnosis assistant (Beta).", true, 10, "veterinarians_approved_beta", Date(now - 30 * 86400000L), Date(now - 5 * 3600000L), "admin_john"),
+            FeatureFlag("marketplace_commission_increase_test", "A/B Test: Increase marketplace commission from 5% to 7% for a subset of new sellers.", true, 5, "new_sellers_last_7_days", Date(now - 3 * 86400000L), Date(now - 1 * 86400000L), "admin_jane"),
+            FeatureFlag("disable_legacy_reporting", "Disable the old reporting system for users who have migrated to the new one.", false, 0, "migrated_users_group_A", Date(now - 5 * 86400000L), Date(now - 5 * 86400000L), "admin_john")
+        ).sortedBy { it.name }
+    }
+
+    fun createFlag(name: String, description: String, targetSegment: String, createdBy: String) {
+        if (_featureFlags.value.any { it.name == name }) {
+            // Ideally, show an error message to the user
+            println("Error: Feature flag '$name' already exists.")
+            return
+        }
+        val newFlag = FeatureFlag(name, description, false, 0, targetSegment, Date(), Date(), createdBy)
+        _featureFlags.update { (it + newFlag).sortedBy { f -> f.name } }
+    }
+
+    fun updateFlagStatus(name: String, isActive: Boolean) {
+        _featureFlags.update { flags ->
+            flags.map { if (it.name == name) it.copy(isActive = isActive, updatedAt = Date()) else it }
+        }
+    }
+
+    fun updateRolloutPercentage(name: String, percentage: Int) {
+        if (percentage < 0 || percentage > 100) {
+             println("Error: Percentage must be between 0 and 100.")
+            return
+        }
+        _featureFlags.update { flags ->
+            flags.map { if (it.name == name) it.copy(rolloutPercentage = percentage, updatedAt = Date()) else it }
+        }
+    }
+
+    fun updateTargetSegment(name: String, segment: String) {
+        _featureFlags.update { flags ->
+            flags.map { if (it.name == name) it.copy(targetUserSegment = segment, updatedAt = Date()) else it }
+        }
+    }
+
+    fun updateDescription(name: String, description: String) {
+        _featureFlags.update { flags ->
+            flags.map { if (it.name == name) it.copy(description = description, updatedAt = Date()) else it }
+        }
+    }
+
+    fun deleteFlag(name: String) {
+        _featureFlags.update { flags -> flags.filterNot { it.name == name } }
+    }
+}
+
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FeatureFlagScreen(viewModel: FeatureFlagViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val flags by viewModel.featureFlags.collectAsState()
+    var showEditDialog by remember { mutableStateOf(false) }
+    var showCreateDialog by remember { mutableStateOf(false) }
+    var currentEditingFlag by remember { mutableStateOf<FeatureFlag?>(null) }
+
+    // State for Create Dialog
+    var newFlagName by remember { mutableStateOf("") }
+    var newFlagDesc by remember { mutableStateOf("") }
+    var newFlagSegment by remember { mutableStateOf("") }
+
+
+    if (showCreateDialog) {
+        AlertDialog(
+            onDismissRequest = { showCreateDialog = false },
+            title = { Text("Create New Feature Flag") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedTextField(value = newFlagName, onValueChange = { newFlagName = it }, label = { Text("Flag Name (ID)") }, singleLine = true)
+                    OutlinedTextField(value = newFlagDesc, onValueChange = { newFlagDesc = it }, label = { Text("Description") })
+                    OutlinedTextField(value = newFlagSegment, onValueChange = { newFlagSegment = it }, label = { Text("Target Segment") }, singleLine = true)
+                }
+            },
+            confirmButton = {
+                Button(onClick = {
+                    if (newFlagName.isNotBlank() && newFlagDesc.isNotBlank() && newFlagSegment.isNotBlank()) {
+                        viewModel.createFlag(newFlagName.trim(), newFlagDesc.trim(), newFlagSegment.trim(), "admin_compose_ui")
+                        showCreateDialog = false
+                        newFlagName = ""; newFlagDesc = ""; newFlagSegment = ""
+                    }
+                }) { Text("Create") }
+            },
+            dismissButton = { Button(onClick = { showCreateDialog = false }) { Text("Cancel") } }
+        )
+    }
+
+    currentEditingFlag?.let { flag ->
+        if (showEditDialog) {
+            EditFeatureFlagDialog(
+                flag = flag,
+                viewModel = viewModel,
+                onDismiss = { showEditDialog = false; currentEditingFlag = null }
+            )
+        }
+    }
+
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Feature Flag Management") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color(0xFF4CAF50)) // A green color
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = {
+                newFlagName = ""; newFlagDesc = ""; newFlagSegment = "" // Clear fields before showing
+                showCreateDialog = true
+            }) {
+                Icon(Icons.Filled.Add, "Create new flag")
+            }
+        }
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = Modifier.padding(paddingValues).padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            items(flags, key = { it.name }) { flag -> // Added key for better performance
+                FeatureFlagCard(
+                    flag = flag,
+                    onEditClick = {
+                        currentEditingFlag = it
+                        showEditDialog = true
+                    },
+                    onDeleteClick = { viewModel.deleteFlag(it.name) },
+                    onToggleStatus = { viewModel.updateFlagStatus(flag.name, !flag.isActive) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun FeatureFlagCard(
+    flag: FeatureFlag,
+    onEditClick: (FeatureFlag) -> Unit,
+    onDeleteClick: (FeatureFlag) -> Unit,
+    onToggleStatus: () -> Unit
+) {
+    Card(elevation = CardDefaults.cardElevation(defaultElevation = 2.dp), modifier = Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(flag.name, style = MaterialTheme.typography.titleLarge)
+            Text("Description: ${flag.description}", style = MaterialTheme.typography.bodyMedium)
+            Text("Target Segment: ${flag.targetUserSegment}", style = MaterialTheme.typography.bodySmall)
+            Text("Rollout: ${flag.rolloutPercentage}%", style = MaterialTheme.typography.bodySmall)
+            Text("Created By: ${flag.createdBy} at ${flag.formattedCreatedAt}", style = MaterialTheme.typography.bodySmall)
+            Text("Last Updated: ${flag.formattedUpdatedAt}", style = MaterialTheme.typography.bodySmall)
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(top = 8.dp).fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                     Text("Active: ", style = MaterialTheme.typography.labelMedium)
+                     Switch(checked = flag.isActive, onCheckedChange = { onToggleStatus() })
+                }
+                Row {
+                    IconButton(onClick = { onEditClick(flag) }) {
+                        Icon(Icons.Filled.Edit, "Edit Flag")
+                    }
+                    IconButton(onClick = { onDeleteClick(flag) }) {
+                        Icon(Icons.Filled.Delete, "Delete Flag", tint = MaterialTheme.colorScheme.error)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun EditFeatureFlagDialog(
+    flag: FeatureFlag,
+    viewModel: FeatureFlagViewModel,
+    onDismiss: () -> Unit
+) {
+    var description by remember { mutableStateOf(flag.description) }
+    var rolloutPercentage by remember { mutableStateOf(flag.rolloutPercentage.toString()) }
+    var targetSegment by remember { mutableStateOf(flag.targetUserSegment) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Edit: ${flag.name}") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(value = description, onValueChange = { description = it }, label = { Text("Description") })
+                OutlinedTextField(
+                    value = rolloutPercentage,
+                    onValueChange = { newValue ->
+                        val filtered = newValue.filter { char -> char.isDigit() }
+                        if (filtered.isEmpty() || (filtered.toIntOrNull() ?: 0) <= 100) {
+                             rolloutPercentage = filtered
+                        } else if (filtered.toInt() > 100) {
+                            rolloutPercentage = "100"
+                        }
+                    },
+                    label = { Text("Rollout % (0-100)") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    singleLine = true
+                )
+                OutlinedTextField(value = targetSegment, onValueChange = { targetSegment = it }, label = { Text("Target Segment") }, singleLine = true)
+            }
+        },
+        confirmButton = {
+            Button(onClick = {
+                viewModel.updateDescription(flag.name, description.trim())
+                val percentValue = rolloutPercentage.toIntOrNull() ?: flag.rolloutPercentage
+                viewModel.updateRolloutPercentage(flag.name, if(percentValue in 0..100) percentValue else flag.rolloutPercentage)
+                viewModel.updateTargetSegment(flag.name, targetSegment.trim())
+                onDismiss()
+            }) { Text("Save Changes") }
+        },
+        dismissButton = { Button(onClick = onDismiss) { Text("Cancel") } }
+    )
+}
+
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewFeatureFlagScreen() {
+    MaterialTheme {
+        FeatureFlagScreen(viewModel = FeatureFlagViewModel())
+    }
+}

--- a/app/src/main/java/com/example/rooster/admin/systemmonitoring/SystemMonitoringScreen.kt
+++ b/app/src/main/java/com/example/rooster/admin/systemmonitoring/SystemMonitoringScreen.kt
@@ -1,0 +1,374 @@
+package com.example.rooster.admin.systemmonitoring
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+// --- Data classes to mirror Python structure ---
+data class ServerHealthData(
+    val name: String,
+    val status: String,
+    val cpuUsage: String,
+    val memoryUsage: String
+)
+
+data class ApiPerformanceData(
+    val endpoint: String,
+    val avgResponseTime: String,
+    val errorRate: String,
+    val requestsPerMinute: Int
+)
+
+data class ErrorLogData(
+    val timestamp: Date,
+    val errorCode: Int,
+    val message: String,
+    val source: String
+) {
+    fun getFormattedTimestamp(): String {
+        val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
+        return sdf.format(timestamp)
+    }
+}
+
+// --- ViewModel to hold and manage UI state ---
+// In a real app, HiltViewModel would be used for DI
+class SystemMonitoringViewModel : ViewModel() {
+    // Mock data similar to Python script
+    private val _serverHealth = MutableStateFlow<List<ServerHealthData>>(emptyList())
+    val serverHealth: StateFlow<List<ServerHealthData>> = _serverHealth
+
+    private val _apiPerformance = MutableStateFlow<List<ApiPerformanceData>>(emptyList())
+    val apiPerformance: StateFlow<List<ApiPerformanceData>> = _apiPerformance
+
+    private val _errorTracking = MutableStateFlow<List<ErrorLogData>>(emptyList())
+    val errorTracking: StateFlow<List<ErrorLogData>> = _errorTracking
+
+    init {
+        loadMockData()
+    }
+
+    private fun loadMockData() {
+        _serverHealth.value = listOf(
+            ServerHealthData("server1", "online", "15%", "45GB/64GB"),
+            ServerHealthData("server2", "online", "25%", "50GB/64GB"),
+            ServerHealthData("server3", "offline", "N/A", "N/A")
+        )
+
+        _apiPerformance.value = listOf(
+            ApiPerformanceData("/api/users", "120ms", "0.5%", 1200),
+            ApiPerformanceData("/api/pets", "150ms", "1.2%", 800),
+            ApiPerformanceData("/api/consultations", "200ms", "0.2%", 500)
+        )
+
+        _errorTracking.value = listOf(
+            ErrorLogData(Date(System.currentTimeMillis() - 5 * 60000), 500, "Internal Server Error on /api/payments", "server2"),
+            ErrorLogData(Date(System.currentTimeMillis() - 15 * 60000), 404, "Resource not found on /api/users/unknown", "server1"),
+            ErrorLogData(Date(System.currentTimeMillis() - 30 * 60000), 403, "Forbidden access to /api/admin/config", "server1")
+        )
+    }
+}
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SystemMonitoringScreen(viewModel: SystemMonitoringViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val serverHealthData by viewModel.serverHealth.collectAsState()
+    val apiPerformanceData by viewModel.apiPerformance.collectAsState()
+    val errorTrackingData by viewModel.errorTracking.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("System Monitoring") },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = Color.LightGray // Example color
+                )
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(modifier = Modifier.padding(paddingValues).padding(16.dp)) {
+            item {
+                Text("Server Health", style = androidx.compose.material3.MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(bottom = 8.dp))
+            }
+            items(serverHealthData) { server ->
+                ServerHealthCard(server)
+            }
+
+            item {
+                Text("API Performance", style = androidx.compose.material3.MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(top = 16.dp, bottom = 8.dp))
+            }
+            items(apiPerformanceData) { api ->
+                ApiPerformanceCard(api)
+            }
+
+            item {
+                Text("Error Tracking", style = androidx.compose.material3.MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(top = 16.dp, bottom = 8.dp))
+            }
+            items(errorTrackingData) { errorLog ->
+                ErrorLogCard(errorLog)
+            }
+        }
+    }
+}
+
+@Composable
+fun ServerHealthCard(data: ServerHealthData) {
+    Card(
+        modifier = Modifier.padding(vertical = 4.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Server: ${data.name}", style = androidx.compose.material3.MaterialTheme.typography.titleMedium)
+            Text("Status: ${data.status}", color = if (data.status == "online") Color.Green else Color.Red)
+            Text("CPU Usage: ${data.cpuUsage}")
+            Text("Memory: ${data.memoryUsage}")
+        }
+    }
+}
+
+@Composable
+fun ApiPerformanceCard(data: ApiPerformanceData) {
+    Card(
+        modifier = Modifier.padding(vertical = 4.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Endpoint: ${data.endpoint}", style = androidx.compose.material3.MaterialTheme.typography.titleMedium)
+            Text("Avg Response: ${data.avgResponseTime}")
+            Text("Error Rate: ${data.errorRate}")
+            Text("RPM: ${data.requestsPerMinute}")
+        }
+    }
+}
+
+@Composable
+fun ErrorLogCard(data: ErrorLogData) {
+    Card(
+        modifier = Modifier.padding(vertical = 4.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Error: ${data.errorCode} - ${data.message}", style = androidx.compose.material3.MaterialTheme.typography.titleMedium)
+            Text("Source: ${data.source}")
+            Text("Timestamp: ${data.getFormattedTimestamp()}")
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewSystemMonitoringScreen() {
+    // You might need to provide a mock ViewModel or use hardcoded data for previews
+    // if the default viewModel() call doesn't work well in previews without Hilt setup.
+    // For simplicity, we'll assume the default viewModel() works or use a simple instance.
+    SystemMonitoringScreen(viewModel = SystemMonitoringViewModel())
+}
+package com.example.rooster.admin.systemmonitoring
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+// --- Data classes to mirror Python structure ---
+data class ServerHealthData(
+    val name: String,
+    val status: String,
+    val cpuUsage: String,
+    val memoryUsage: String
+)
+
+data class ApiPerformanceData(
+    val endpoint: String,
+    val avgResponseTime: String,
+    val errorRate: String,
+    val requestsPerMinute: Int
+)
+
+data class ErrorLogData(
+    val timestamp: Date,
+    val errorCode: Int,
+    val message: String,
+    val source: String
+) {
+    fun getFormattedTimestamp(): String {
+        val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
+        return sdf.format(timestamp)
+    }
+}
+
+// --- ViewModel to hold and manage UI state ---
+// In a real app, HiltViewModel would be used for DI
+class SystemMonitoringViewModel : ViewModel() {
+    // Mock data similar to Python script
+    private val _serverHealth = MutableStateFlow<List<ServerHealthData>>(emptyList())
+    val serverHealth: StateFlow<List<ServerHealthData>> = _serverHealth
+
+    private val _apiPerformance = MutableStateFlow<List<ApiPerformanceData>>(emptyList())
+    val apiPerformance: StateFlow<List<ApiPerformanceData>> = _apiPerformance
+
+    private val _errorTracking = MutableStateFlow<List<ErrorLogData>>(emptyList())
+    val errorTracking: StateFlow<List<ErrorLogData>> = _errorTracking
+
+    init {
+        loadMockData()
+    }
+
+    private fun loadMockData() {
+        _serverHealth.value = listOf(
+            ServerHealthData("server1", "online", "15%", "45GB/64GB"),
+            ServerHealthData("server2", "online", "25%", "50GB/64GB"),
+            ServerHealthData("server3", "offline", "N/A", "N/A")
+        )
+
+        _apiPerformance.value = listOf(
+            ApiPerformanceData("/api/users", "120ms", "0.5%", 1200),
+            ApiPerformanceData("/api/pets", "150ms", "1.2%", 800),
+            ApiPerformanceData("/api/consultations", "200ms", "0.2%", 500)
+        )
+
+        _errorTracking.value = listOf(
+            ErrorLogData(Date(System.currentTimeMillis() - 5 * 60000), 500, "Internal Server Error on /api/payments", "server2"),
+            ErrorLogData(Date(System.currentTimeMillis() - 15 * 60000), 404, "Resource not found on /api/users/unknown", "server1"),
+            ErrorLogData(Date(System.currentTimeMillis() - 30 * 60000), 403, "Forbidden access to /api/admin/config", "server1")
+        )
+    }
+}
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SystemMonitoringScreen(viewModel: SystemMonitoringViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val serverHealthData by viewModel.serverHealth.collectAsState()
+    val apiPerformanceData by viewModel.apiPerformance.collectAsState()
+    val errorTrackingData by viewModel.errorTracking.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("System Monitoring") },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = Color.LightGray // Example color
+                )
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(modifier = Modifier.padding(paddingValues).padding(16.dp)) {
+            item {
+                Text("Server Health", style = androidx.compose.material3.MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(bottom = 8.dp))
+            }
+            items(serverHealthData) { server ->
+                ServerHealthCard(server)
+            }
+
+            item {
+                Text("API Performance", style = androidx.compose.material3.MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(top = 16.dp, bottom = 8.dp))
+            }
+            items(apiPerformanceData) { api ->
+                ApiPerformanceCard(api)
+            }
+
+            item {
+                Text("Error Tracking", style = androidx.compose.material3.MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(top = 16.dp, bottom = 8.dp))
+            }
+            items(errorTrackingData) { errorLog ->
+                ErrorLogCard(errorLog)
+            }
+        }
+    }
+}
+
+@Composable
+fun ServerHealthCard(data: ServerHealthData) {
+    Card(
+        modifier = Modifier.padding(vertical = 4.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Server: ${data.name}", style = androidx.compose.material3.MaterialTheme.typography.titleMedium)
+            Text("Status: ${data.status}", color = if (data.status == "online") Color.Green else Color.Red)
+            Text("CPU Usage: ${data.cpuUsage}")
+            Text("Memory: ${data.memoryUsage}")
+        }
+    }
+}
+
+@Composable
+fun ApiPerformanceCard(data: ApiPerformanceData) {
+    Card(
+        modifier = Modifier.padding(vertical = 4.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Endpoint: ${data.endpoint}", style = androidx.compose.material3.MaterialTheme.typography.titleMedium)
+            Text("Avg Response: ${data.avgResponseTime}")
+            Text("Error Rate: ${data.errorRate}")
+            Text("RPM: ${data.requestsPerMinute}")
+        }
+    }
+}
+
+@Composable
+fun ErrorLogCard(data: ErrorLogData) {
+    Card(
+        modifier = Modifier.padding(vertical = 4.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Error: ${data.errorCode} - ${data.message}", style = androidx.compose.material3.MaterialTheme.typography.titleMedium)
+            Text("Source: ${data.source}")
+            Text("Timestamp: ${data.getFormattedTimestamp()}")
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewSystemMonitoringScreen() {
+    // You might need to provide a mock ViewModel or use hardcoded data for previews
+    // if the default viewModel() call doesn't work well in previews without Hilt setup.
+    // For simplicity, we'll assume the default viewModel() works or use a simple instance.
+    SystemMonitoringScreen(viewModel = SystemMonitoringViewModel())
+}

--- a/app/src/main/java/com/example/rooster/admin/usermanagement/UserManagementScreen.kt
+++ b/app/src/main/java/com/example/rooster/admin/usermanagement/UserManagementScreen.kt
@@ -1,0 +1,502 @@
+package com.example.rooster.admin.usermanagement
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AddCircle
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Face
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+// --- Data Classes ---
+data class UserProfile(
+    val name: String,
+    val details: Map<String, String> // e.g., specialty, farm_size
+)
+
+data class UserData(
+    val id: String,
+    val email: String,
+    var isVerified: Boolean,
+    var roles: List<String>,
+    var accountStatus: String,
+    val lastLogin: Date?,
+    val profile: UserProfile?
+) {
+    fun getFormattedLastLogin(): String {
+        return lastLogin?.let {
+            SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(it)
+        } ?: "Never"
+    }
+}
+
+// --- ViewModel ---
+class UserManagementViewModel : ViewModel() {
+    private val _users = MutableStateFlow<List<UserData>>(emptyList())
+    val users: StateFlow<List<UserData>> = _users
+
+    init {
+        loadMockUsers()
+    }
+
+    private fun loadMockUsers() {
+        _users.value = listOf(
+            UserData(
+                "user001", "alice@example.com", true, listOf("veterinarian", "admin"), "active",
+                Date(System.currentTimeMillis() - 2 * 3600000),
+                UserProfile("Dr. Alice Smith", mapOf("specialty" to "General Practice"))
+            ),
+            UserData(
+                "user002", "bob@example.com", false, listOf("farmer"), "pending_verification",
+                null,
+                UserProfile("Bob Johnson", mapOf("farm_size" to "100 acres"))
+            ),
+            UserData(
+                "user003", "charlie@example.com", true, listOf("farmer", "seller"), "active",
+                Date(System.currentTimeMillis() - 24 * 3600000),
+                UserProfile("Charlie Brown", mapOf("store_name" to "Brown's Farm Produce"))
+            ),
+            UserData(
+                "user004", "diana@example.com", true, listOf("veterinarian"), "suspended",
+                Date(System.currentTimeMillis() - 7 * 24 * 3600000),
+                UserProfile("Dr. Diana Prince", mapOf("specialty" to "Surgery"))
+            )
+        )
+    }
+
+    fun verifyUser(userId: String) {
+        _users.update { currentUsers ->
+            currentUsers.map { user ->
+                if (user.id == userId) {
+                    user.copy(isVerified = true, accountStatus = "active")
+                } else user
+            }
+        }
+    }
+
+    fun assignRole(userId: String, role: String) {
+        _users.update { currentUsers ->
+            currentUsers.map { user ->
+                if (user.id == userId && !user.roles.contains(role)) {
+                    user.copy(roles = user.roles + role)
+                } else user
+            }
+        }
+    }
+
+    fun revokeRole(userId: String, role: String) {
+        _users.update { currentUsers ->
+            currentUsers.map { user ->
+                if (user.id == userId && user.roles.contains(role)) {
+                    user.copy(roles = user.roles - role)
+                } else user
+            }
+        }
+    }
+
+    fun changeAccountStatus(userId: String, newStatus: String) {
+        _users.update { currentUsers ->
+            currentUsers.map { user ->
+                if (user.id == userId) {
+                    user.copy(accountStatus = newStatus)
+                } else user
+            }
+        }
+    }
+}
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun UserManagementScreen(viewModel: UserManagementViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val users by viewModel.users.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("User Management") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Cyan) // Example color
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = Modifier
+                .padding(paddingValues)
+                .padding(16.dp)
+        ) {
+            items(users) { user ->
+                UserCard(user, viewModel)
+            }
+        }
+    }
+}
+
+@Composable
+fun UserCard(user: UserData, viewModel: UserManagementViewModel) {
+    var showDialog by remember { mutableStateOf(false) }
+    var actionType by remember { mutableStateOf("") } // "assignRole", "revokeRole", "changeStatus"
+    var inputValue by remember { mutableStateOf("") }
+
+
+    if (showDialog) {
+        AlertDialog(
+            onDismissRequest = { showDialog = false },
+            title = { Text("Perform Action on ${user.email}") },
+            text = {
+                Column {
+                    Text("Current Status: ${user.accountStatus}")
+                    Text("Current Roles: ${user.roles.joinToString()}")
+                    if (actionType == "assignRole" || actionType == "revokeRole") {
+                        OutlinedTextField(
+                            value = inputValue,
+                            onValueChange = { inputValue = it },
+                            label = { Text("Role Name") }
+                        )
+                    } else if (actionType == "changeStatus") {
+                         OutlinedTextField(
+                            value = inputValue,
+                            onValueChange = { inputValue = it },
+                            label = { Text("New Status (e.g., active, suspended)") }
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                Button(onClick = {
+                    when (actionType) {
+                        "assignRole" -> viewModel.assignRole(user.id, inputValue)
+                        "revokeRole" -> viewModel.revokeRole(user.id, inputValue)
+                        "changeStatus" -> viewModel.changeAccountStatus(user.id, inputValue)
+                    }
+                    showDialog = false
+                    inputValue = ""
+                }) { Text("Confirm") }
+            },
+            dismissButton = {
+                Button(onClick = { showDialog = false }) { Text("Cancel") }
+            }
+        )
+    }
+
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("ID: ${user.id}", style = MaterialTheme.typography.titleMedium)
+            Text("Email: ${user.email}")
+            Text("Verified: ${if (user.isVerified) "Yes" else "No"}", color = if (user.isVerified) Color.Green else Color.Red)
+            Text("Roles: ${user.roles.joinToString(", ")}")
+            Text("Status: ${user.accountStatus}", color = when(user.accountStatus){
+                "active" -> Color.Green
+                "pending_verification" -> Color.Blue
+                "suspended" -> Color.Magenta
+                else -> Color.Gray
+            })
+            Text("Last Login: ${user.getFormattedLastLogin()}")
+            user.profile?.let { profile ->
+                Text("Profile Name: ${profile.name}")
+                profile.details.forEach { (key, value) ->
+                    Text("${key.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }}: $value")
+                }
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceAround
+            ) {
+                if (!user.isVerified) {
+                    Button(onClick = { viewModel.verifyUser(user.id) }) {
+                        Text("Verify")
+                    }
+                }
+                IconButton(onClick = { actionType = "assignRole"; inputValue = ""; showDialog = true }) {
+                    Icon(Icons.Default.AddCircle, contentDescription = "Assign Role")
+                }
+                IconButton(onClick = { actionType = "revokeRole"; inputValue = ""; showDialog = true }) {
+                    Icon(Icons.Default.Delete, contentDescription = "Revoke Role")
+                }
+                 IconButton(onClick = { actionType = "changeStatus"; inputValue = user.accountStatus; showDialog = true }) {
+                    Icon(Icons.Default.Edit, contentDescription = "Change Status")
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewUserManagementScreen() {
+    MaterialTheme { // Wrap in MaterialTheme for preview
+        UserManagementScreen(viewModel = UserManagementViewModel())
+    }
+}
+package com.example.rooster.admin.usermanagement
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AddCircle
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Face
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+// --- Data Classes ---
+data class UserProfile(
+    val name: String,
+    val details: Map<String, String> // e.g., specialty, farm_size
+)
+
+data class UserData(
+    val id: String,
+    val email: String,
+    var isVerified: Boolean,
+    var roles: List<String>,
+    var accountStatus: String,
+    val lastLogin: Date?,
+    val profile: UserProfile?
+) {
+    fun getFormattedLastLogin(): String {
+        return lastLogin?.let {
+            SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(it)
+        } ?: "Never"
+    }
+}
+
+// --- ViewModel ---
+class UserManagementViewModel : ViewModel() {
+    private val _users = MutableStateFlow<List<UserData>>(emptyList())
+    val users: StateFlow<List<UserData>> = _users
+
+    init {
+        loadMockUsers()
+    }
+
+    private fun loadMockUsers() {
+        _users.value = listOf(
+            UserData(
+                "user001", "alice@example.com", true, listOf("veterinarian", "admin"), "active",
+                Date(System.currentTimeMillis() - 2 * 3600000),
+                UserProfile("Dr. Alice Smith", mapOf("specialty" to "General Practice"))
+            ),
+            UserData(
+                "user002", "bob@example.com", false, listOf("farmer"), "pending_verification",
+                null,
+                UserProfile("Bob Johnson", mapOf("farm_size" to "100 acres"))
+            ),
+            UserData(
+                "user003", "charlie@example.com", true, listOf("farmer", "seller"), "active",
+                Date(System.currentTimeMillis() - 24 * 3600000),
+                UserProfile("Charlie Brown", mapOf("store_name" to "Brown's Farm Produce"))
+            ),
+            UserData(
+                "user004", "diana@example.com", true, listOf("veterinarian"), "suspended",
+                Date(System.currentTimeMillis() - 7 * 24 * 3600000),
+                UserProfile("Dr. Diana Prince", mapOf("specialty" to "Surgery"))
+            )
+        )
+    }
+
+    fun verifyUser(userId: String) {
+        _users.update { currentUsers ->
+            currentUsers.map { user ->
+                if (user.id == userId) {
+                    user.copy(isVerified = true, accountStatus = "active")
+                } else user
+            }
+        }
+    }
+
+    fun assignRole(userId: String, role: String) {
+        _users.update { currentUsers ->
+            currentUsers.map { user ->
+                if (user.id == userId && !user.roles.contains(role)) {
+                    user.copy(roles = user.roles + role)
+                } else user
+            }
+        }
+    }
+
+    fun revokeRole(userId: String, role: String) {
+        _users.update { currentUsers ->
+            currentUsers.map { user ->
+                if (user.id == userId && user.roles.contains(role)) {
+                    user.copy(roles = user.roles - role)
+                } else user
+            }
+        }
+    }
+
+    fun changeAccountStatus(userId: String, newStatus: String) {
+        _users.update { currentUsers ->
+            currentUsers.map { user ->
+                if (user.id == userId) {
+                    user.copy(accountStatus = newStatus)
+                } else user
+            }
+        }
+    }
+}
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun UserManagementScreen(viewModel: UserManagementViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val users by viewModel.users.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("User Management") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Cyan) // Example color
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = Modifier
+                .padding(paddingValues)
+                .padding(16.dp)
+        ) {
+            items(users) { user ->
+                UserCard(user, viewModel)
+            }
+        }
+    }
+}
+
+@Composable
+fun UserCard(user: UserData, viewModel: UserManagementViewModel) {
+    var showDialog by remember { mutableStateOf(false) }
+    var actionType by remember { mutableStateOf("") } // "assignRole", "revokeRole", "changeStatus"
+    var inputValue by remember { mutableStateOf("") }
+
+
+    if (showDialog) {
+        AlertDialog(
+            onDismissRequest = { showDialog = false },
+            title = { Text("Perform Action on ${user.email}") },
+            text = {
+                Column {
+                    Text("Current Status: ${user.accountStatus}")
+                    Text("Current Roles: ${user.roles.joinToString()}")
+                    if (actionType == "assignRole" || actionType == "revokeRole") {
+                        OutlinedTextField(
+                            value = inputValue,
+                            onValueChange = { inputValue = it },
+                            label = { Text("Role Name") }
+                        )
+                    } else if (actionType == "changeStatus") {
+                         OutlinedTextField(
+                            value = inputValue,
+                            onValueChange = { inputValue = it },
+                            label = { Text("New Status (e.g., active, suspended)") }
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                Button(onClick = {
+                    when (actionType) {
+                        "assignRole" -> viewModel.assignRole(user.id, inputValue)
+                        "revokeRole" -> viewModel.revokeRole(user.id, inputValue)
+                        "changeStatus" -> viewModel.changeAccountStatus(user.id, inputValue)
+                    }
+                    showDialog = false
+                    inputValue = ""
+                }) { Text("Confirm") }
+            },
+            dismissButton = {
+                Button(onClick = { showDialog = false }) { Text("Cancel") }
+            }
+        )
+    }
+
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("ID: ${user.id}", style = MaterialTheme.typography.titleMedium)
+            Text("Email: ${user.email}")
+            Text("Verified: ${if (user.isVerified) "Yes" else "No"}", color = if (user.isVerified) Color.Green else Color.Red)
+            Text("Roles: ${user.roles.joinToString(", ")}")
+            Text("Status: ${user.accountStatus}", color = when(user.accountStatus){
+                "active" -> Color.Green
+                "pending_verification" -> Color.Blue
+                "suspended" -> Color.Magenta
+                else -> Color.Gray
+            })
+            Text("Last Login: ${user.getFormattedLastLogin()}")
+            user.profile?.let { profile ->
+                Text("Profile Name: ${profile.name}")
+                profile.details.forEach { (key, value) ->
+                    Text("${key.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }}: $value")
+                }
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceAround
+            ) {
+                if (!user.isVerified) {
+                    Button(onClick = { viewModel.verifyUser(user.id) }) {
+                        Text("Verify")
+                    }
+                }
+                IconButton(onClick = { actionType = "assignRole"; inputValue = ""; showDialog = true }) {
+                    Icon(Icons.Default.AddCircle, contentDescription = "Assign Role")
+                }
+                IconButton(onClick = { actionType = "revokeRole"; inputValue = ""; showDialog = true }) {
+                    Icon(Icons.Default.Delete, contentDescription = "Revoke Role")
+                }
+                 IconButton(onClick = { actionType = "changeStatus"; inputValue = user.accountStatus; showDialog = true }) {
+                    Icon(Icons.Default.Edit, contentDescription = "Change Status")
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewUserManagementScreen() {
+    MaterialTheme { // Wrap in MaterialTheme for preview
+        UserManagementScreen(viewModel = UserManagementViewModel())
+    }
+}

--- a/app/src/main/java/com/example/rooster/financials/commission/CommissionPlaceholder.kt
+++ b/app/src/main/java/com/example/rooster/financials/commission/CommissionPlaceholder.kt
@@ -1,0 +1,4 @@
+// Placeholder for Commission Management feature
+package com.example.rooster.financials.commission
+
+class CommissionPlaceholder {}

--- a/app/src/main/java/com/example/rooster/financials/payouts/PayoutsPlaceholder.kt
+++ b/app/src/main/java/com/example/rooster/financials/payouts/PayoutsPlaceholder.kt
@@ -1,0 +1,4 @@
+// Placeholder for Payout System feature
+package com.example.rooster.financials.payouts
+
+class PayoutsPlaceholder {}

--- a/app/src/main/java/com/example/rooster/financials/reports/FinancialReportsPlaceholder.kt
+++ b/app/src/main/java/com/example/rooster/financials/reports/FinancialReportsPlaceholder.kt
@@ -1,0 +1,4 @@
+// Placeholder for Financial Reports feature
+package com.example.rooster.financials.reports
+
+class FinancialReportsPlaceholder {}

--- a/app/src/main/java/com/example/rooster/financials/revenueanalytics/RevenueAnalyticsPlaceholder.kt
+++ b/app/src/main/java/com/example/rooster/financials/revenueanalytics/RevenueAnalyticsPlaceholder.kt
@@ -1,0 +1,4 @@
+// Placeholder for Revenue Analytics feature
+package com.example.rooster.financials.revenueanalytics
+
+class RevenueAnalyticsPlaceholder {}

--- a/app/src/main/java/com/example/rooster/financials/transactions/TransactionsPlaceholder.kt
+++ b/app/src/main/java/com/example/rooster/financials/transactions/TransactionsPlaceholder.kt
@@ -1,0 +1,4 @@
+// Placeholder for Transaction Monitoring feature
+package com.example.rooster.financials.transactions
+
+class TransactionsPlaceholder {}

--- a/app/src/main/java/com/example/rooster/professionaltools/casestudies/CaseStudiesPlaceholder.kt
+++ b/app/src/main/java/com/example/rooster/professionaltools/casestudies/CaseStudiesPlaceholder.kt
@@ -1,0 +1,4 @@
+// Placeholder for Case Studies feature
+package com.example.rooster.professionaltools.casestudies
+
+class CaseStudiesPlaceholder {}

--- a/app/src/main/java/com/example/rooster/professionaltools/diagnosisassistant/DiagnosisAssistantPlaceholder.kt
+++ b/app/src/main/java/com/example/rooster/professionaltools/diagnosisassistant/DiagnosisAssistantPlaceholder.kt
@@ -1,0 +1,4 @@
+// Placeholder for Diagnosis Assistant feature
+package com.example.rooster.professionaltools.diagnosisassistant
+
+class DiagnosisAssistantPlaceholder {}

--- a/app/src/main/java/com/example/rooster/professionaltools/educationalcontent/EducationalContentPlaceholder.kt
+++ b/app/src/main/java/com/example/rooster/professionaltools/educationalcontent/EducationalContentPlaceholder.kt
@@ -1,0 +1,4 @@
+// Placeholder for Educational Content feature
+package com.example.rooster.professionaltools.educationalcontent
+
+class EducationalContentPlaceholder {}

--- a/app/src/main/java/com/example/rooster/professionaltools/vetnetwork/VetNetworkPlaceholder.kt
+++ b/app/src/main/java/com/example/rooster/professionaltools/vetnetwork/VetNetworkPlaceholder.kt
@@ -1,0 +1,4 @@
+// Placeholder for Veterinary Network feature
+package com.example.rooster.professionaltools.vetnetwork
+
+class VetNetworkPlaceholder {}

--- a/app/src/main/java/com/example/rooster/veterinary/consultations/ConsultationsPlaceholder.kt
+++ b/app/src/main/java/com/example/rooster/veterinary/consultations/ConsultationsPlaceholder.kt
@@ -1,0 +1,4 @@
+// Placeholder for Vet Consultation feature
+package com.example.rooster.veterinary.consultations
+
+class ConsultationsPlaceholder {}

--- a/app/src/main/java/com/example/rooster/veterinary/healthalerts/HealthAlertsPlaceholder.kt
+++ b/app/src/main/java/com/example/rooster/veterinary/healthalerts/HealthAlertsPlaceholder.kt
@@ -1,0 +1,4 @@
+// Placeholder for Health Alert System feature
+package com.example.rooster.veterinary.healthalerts
+
+class HealthAlertsPlaceholder {}

--- a/app/src/main/java/com/example/rooster/veterinary/patienthistory/PatientHistoryPlaceholder.kt
+++ b/app/src/main/java/com/example/rooster/veterinary/patienthistory/PatientHistoryPlaceholder.kt
@@ -1,0 +1,4 @@
+// Placeholder for Patient History feature
+package com.example.rooster.veterinary.patienthistory
+
+class PatientHistoryPlaceholder {}

--- a/app/src/main/java/com/example/rooster/veterinary/prescriptions/PrescriptionsPlaceholder.kt
+++ b/app/src/main/java/com/example/rooster/veterinary/prescriptions/PrescriptionsPlaceholder.kt
@@ -1,0 +1,4 @@
+// Placeholder for Prescription Management feature
+package com.example.rooster.veterinary.prescriptions
+
+class PrescriptionsPlaceholder {}

--- a/app/src/main/java/com/example/rooster/veterinary/telemedicine/TelemedicinePlaceholder.kt
+++ b/app/src/main/java/com/example/rooster/veterinary/telemedicine/TelemedicinePlaceholder.kt
@@ -1,0 +1,4 @@
+// Placeholder for Telemedicine feature
+package com.example.rooster.veterinary.telemedicine
+
+class TelemedicinePlaceholder {}


### PR DESCRIPTION
Converts Python-based admin screens to Android Jetpack Compose UIs.

Includes:
- SystemMonitoringScreen
- UserManagementScreen
- AnalyticsDashboardScreen
- ContentModerationScreen
- FeatureFlagScreen
- AdminDashboardScreen for navigation

All screens use ViewModels with mock data mirroring the original Python scripts. Basic UI interactions and data manipulation logic are implemented. This completes Phase 1 of the conversion plan.