### PR TITLE
feat: Complete conversion of Python modules to Android

### DIFF
--- a/app/src/main/java/com/example/rooster/NavigationRoute.kt
+++ b/app/src/main/java/com/example/rooster/NavigationRoute.kt
@@ -128,6 +128,12 @@ open class NavigationRoute(val route: String) {
     object Diagnostics : NavigationRoute("diagnostics")
 
     object HealthManagement : NavigationRoute("health_management")
+
+    // Routes for new Admin, Financials, Veterinary, and Professional Tools Dashboards
+    object AdminFeaturesDashboard : NavigationRoute("admin_features_dashboard")
+    object FinancialsFeaturesDashboard : NavigationRoute("financials_features_dashboard")
+    object VeterinaryFeaturesDashboard : NavigationRoute("veterinary_features_dashboard")
+    object ProfessionalToolsDashboard : NavigationRoute("professional_tools_dashboard")
     // Add more routes as needed
 
     companion object {

--- a/app/src/main/java/com/example/rooster/admin/AdminDashboardScreen.kt
+++ b/app/src/main/java/com/example/rooster/admin/AdminDashboardScreen.kt
@@ -1,0 +1,90 @@
+package com.example.rooster.admin
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.example.rooster.admin.analytics.AnalyticsDashboardScreen
+import com.example.rooster.admin.contentmoderation.ContentModerationScreen
+import com.example.rooster.admin.featureflags.FeatureFlagScreen
+import com.example.rooster.admin.systemmonitoring.SystemMonitoringScreen
+import com.example.rooster.admin.usermanagement.UserManagementScreen
+
+// --- Navigation Routes ---
+object AdminDestinations {
+    const val DASHBOARD = "admin_dashboard"
+    const val SYSTEM_MONITORING = "admin_system_monitoring"
+    const val USER_MANAGEMENT = "admin_user_management"
+    const val ANALYTICS_DASHBOARD = "admin_analytics_dashboard"
+    const val CONTENT_MODERATION = "admin_content_moderation"
+    const val FEATURE_FLAGS = "admin_feature_flags"
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AdminDashboardScreen(navController: NavController) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Admin Dashboard") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.DarkGray)
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxSize()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            item { AdminDashboardButton(navController, "System Monitoring", AdminDestinations.SYSTEM_MONITORING) }
+            item { AdminDashboardButton(navController, "User Management", AdminDestinations.USER_MANAGEMENT) }
+            item { AdminDashboardButton(navController, "Analytics Dashboard", AdminDestinations.ANALYTICS_DASHBOARD) }
+            item { AdminDashboardButton(navController, "Content Moderation", AdminDestinations.CONTENT_MODERATION) }
+            item { AdminDashboardButton(navController, "Feature Flags", AdminDestinations.FEATURE_FLAGS) }
+        }
+    }
+}
+
+@Composable
+fun AdminDashboardButton(navController: NavController, text: String, route: String) {
+    Button(
+        onClick = { navController.navigate(route) },
+        modifier = Modifier.fillMaxWidth(0.8f).height(50.dp)
+    ) {
+        Text(text)
+    }
+}
+
+@Composable
+fun AdminFeatureNavigator() {
+    val navController = rememberNavController()
+    NavHost(navController = navController, startDestination = AdminDestinations.DASHBOARD) {
+        composable(AdminDestinations.DASHBOARD) { AdminDashboardScreen(navController) }
+        composable(AdminDestinations.SYSTEM_MONITORING) { SystemMonitoringScreen() }
+        composable(AdminDestinations.USER_MANAGEMENT) { UserManagementScreen() }
+        composable(AdminDestinations.ANALYTICS_DASHBOARD) { AnalyticsDashboardScreen() }
+        composable(AdminDestinations.CONTENT_MODERATION) { ContentModerationScreen() }
+        composable(AdminDestinations.FEATURE_FLAGS) { FeatureFlagScreen() }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewAdminDashboardScreen() {
+    MaterialTheme {
+        // Previewing the whole navigator to see dashboard
+        AdminFeatureNavigator()
+    }
+}

--- a/app/src/main/java/com/example/rooster/admin/analytics/AnalyticsDashboardScreen.kt
+++ b/app/src/main/java/com/example/rooster/admin/analytics/AnalyticsDashboardScreen.kt
@@ -1,0 +1,470 @@
+package com.example.rooster.admin.analytics
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import java.text.DecimalFormat
+import java.util.Date
+
+// --- Data Classes ---
+// Using Maps and Any for flexibility, mirroring Python's dictionary structure.
+// For a production app, more specific data classes would be better.
+
+data class KpiData(val metrics: Map<String, Any>)
+data class UserBehaviorData(val metrics: Map<String, Any>)
+data class RevenueTrackingData(val metrics: Map<String, Any>)
+data class SystemPerformanceSummaryData(val metrics: Map<String, Any>)
+data class ContentEngagementData(val metrics: Map<String, Any>)
+data class TimeSeriesDataPoint(val date: String, val value: Number) // For revenue or user counts
+data class TimeSeriesChartData(val name: String, val points: List<TimeSeriesDataPoint>)
+
+
+// --- ViewModel ---
+class AnalyticsDashboardViewModel : ViewModel() {
+    private val _kpis = MutableStateFlow<KpiData?>(null)
+    val kpis: StateFlow<KpiData?> = _kpis
+
+    private val _userBehavior = MutableStateFlow<UserBehaviorData?>(null)
+    val userBehavior: StateFlow<UserBehaviorData?> = _userBehavior
+
+    private val _revenueTracking = MutableStateFlow<RevenueTrackingData?>(null)
+    val revenueTracking: StateFlow<RevenueTrackingData?> = _revenueTracking
+
+    private val _systemPerformance = MutableStateFlow<SystemPerformanceSummaryData?>(null)
+    val systemPerformance: StateFlow<SystemPerformanceSummaryData?> = _systemPerformance
+
+    private val _contentEngagement = MutableStateFlow<ContentEngagementData?>(null)
+    val contentEngagement: StateFlow<ContentEngagementData?> = _contentEngagement
+
+    private val _revenueOverTime = MutableStateFlow<TimeSeriesChartData?>(null)
+    val revenueOverTime: StateFlow<TimeSeriesChartData?> = _revenueOverTime
+
+    private val _newUsersOverTime = MutableStateFlow<TimeSeriesChartData?>(null)
+    val newUsersOverTime: StateFlow<TimeSeriesChartData?> = _newUsersOverTime
+
+    init {
+        loadMockMetrics()
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun loadMockMetrics() {
+        // Mock data similar to Python script
+        _kpis.value = KpiData(mapOf(
+            "total_users" to 15230,
+            "active_users_monthly" to 8500,
+            "active_users_daily" to 1200,
+            "new_signups_last_30_days" to 750,
+            "user_retention_rate" to "65%"
+        ))
+
+        _userBehavior.value = UserBehaviorData(mapOf(
+            "average_session_duration" to "15 minutes",
+            "pages_per_session" to 5.2,
+            "most_visited_feature" to "Veterinary Consultation",
+            "feature_engagement_rate" to mapOf(
+                "Consultations" to "40%",
+                "Marketplace" to "30%",
+                "Educational Content" to "25%",
+                "Forum" to "15%"
+            ),
+            "user_demographics_summary" to mapOf(
+                "top_country" to "USA (60%)",
+                "user_types" to "Farmers (70%), Veterinarians (30%)"
+            )
+        ))
+
+        _revenueTracking.value = RevenueTrackingData(mapOf(
+            "total_revenue_mtd" to 12500.75,
+            "total_revenue_ytd" to 150200.50,
+            "average_revenue_per_user_arpu" to 9.86,
+            "revenue_by_source" to mapOf(
+                "Consultation Fees" to 75000.00,
+                "Marketplace Commissions" to 60200.50,
+                "Subscription Fees" to 15000.00
+            ),
+            "recent_transactions_count_last_24h" to 85
+        ))
+
+        _systemPerformance.value = SystemPerformanceSummaryData(mapOf(
+            "overall_uptime" to "99.98%",
+            "average_api_response_time" to "140ms",
+            "critical_errors_last_24h" to 2
+        ))
+
+        _contentEngagement.value = ContentEngagementData(mapOf(
+            "new_articles_published_last_30d" to 25,
+            "article_views_last_30d" to 15000,
+            "average_time_on_page_articles" to "3 min 45 sec",
+            "most_popular_article_id" to "article_vet_health_basics"
+        ))
+
+        // Mock time series data
+        val today = java.util.Calendar.getInstance()
+        val revenuePoints = (0..29).map { i ->
+            val day = today.clone() as java.util.Calendar
+            day.add(java.util.Calendar.DATE, -i)
+            TimeSeriesDataPoint(
+                date = "${day.get(java.util.Calendar.YEAR)}-${day.get(java.util.Calendar.MONTH) + 1}-${day.get(java.util.Calendar.DAY_OF_MONTH)}",
+                value = (300..800).random().toDouble()
+            )
+        }.reversed()
+        _revenueOverTime.value = TimeSeriesChartData("Revenue Over Time (Daily)", revenuePoints)
+
+        val newUsersPoints = (0..29).map { i ->
+            val day = today.clone() as java.util.Calendar
+            day.add(java.util.Calendar.DATE, -i)
+            TimeSeriesDataPoint(
+                date = "${day.get(java.util.Calendar.YEAR)}-${day.get(java.util.Calendar.MONTH) + 1}-${day.get(java.util.Calendar.DAY_OF_MONTH)}",
+                value = (10..50).random()
+            )
+        }.reversed()
+        _newUsersOverTime.value = TimeSeriesChartData("New Users Over Time (Daily)", newUsersPoints)
+    }
+}
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AnalyticsDashboardScreen(viewModel: AnalyticsDashboardViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val kpis by viewModel.kpis.collectAsState()
+    val userBehavior by viewModel.userBehavior.collectAsState()
+    val revenueTracking by viewModel.revenueTracking.collectAsState()
+    val systemPerformance by viewModel.systemPerformance.collectAsState()
+    val contentEngagement by viewModel.contentEngagement.collectAsState()
+    val revenueOverTime by viewModel.revenueOverTime.collectAsState()
+    val newUsersOverTime by viewModel.newUsersOverTime.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Analytics Dashboard") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Yellow) // Example
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(modifier = Modifier.padding(paddingValues).padding(16.dp)) {
+            kpis?.let { data -> item { AnalyticsSectionCard("Key Performance Indicators", data.metrics) } }
+            userBehavior?.let { data -> item { AnalyticsSectionCard("User Behavior", data.metrics) } }
+            revenueTracking?.let { data -> item { AnalyticsSectionCard("Revenue Tracking", data.metrics) } }
+            systemPerformance?.let { data -> item { AnalyticsSectionCard("System Performance Summary", data.metrics) } }
+            contentEngagement?.let { data -> item { AnalyticsSectionCard("Content Engagement", data.metrics) } }
+
+            revenueOverTime?.let { data -> item { TimeSeriesSection("Revenue Over Last 30 Days (Sample)", data.points) } }
+            newUsersOverTime?.let { data -> item { TimeSeriesSection("New Users Over Last 30 Days (Sample)", data.points) } }
+        }
+    }
+}
+
+@Composable
+fun AnalyticsSectionCard(title: String, metrics: Map<String, Any>) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(title, style = MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(bottom = 8.dp))
+            DisplayMetrics(metrics)
+        }
+    }
+}
+
+@Composable
+fun DisplayMetrics(metrics: Map<String, Any>, indentLevel: Int = 0) {
+    val indent = "  ".repeat(indentLevel)
+    val decimalFormat = DecimalFormat("#,##0.00")
+
+    metrics.forEach { (key, value) ->
+        val displayKey = key.replace("_", " ").replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
+        when (value) {
+            is Map<*, *> -> {
+                Text("$indent$displayKey:")
+                DisplayMetrics(value as Map<String, Any>, indentLevel + 1)
+            }
+            is Double -> Text("$indent$displayKey: $${decimalFormat.format(value)}")
+            is Number -> Text("$indent$displayKey: $value")
+            else -> Text("$indent$displayKey: $value")
+        }
+    }
+}
+
+@Composable
+fun TimeSeriesSection(title: String, dataPoints: List<TimeSeriesDataPoint>) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(title, style = MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(bottom = 8.dp))
+            // Displaying top 5 for brevity, similar to Python's print output
+            dataPoints.take(5).forEach { point ->
+                Text("  Date: ${point.date}, Value: ${point.value}")
+            }
+            if (dataPoints.size > 5) {
+                Text("  ... and more data points")
+            }
+            // Placeholder for chart:
+            // Text("Chart would be displayed here using MPAndroidChart or similar.",
+            //      modifier = Modifier.padding(vertical = 8.dp).fillMaxWidth(),
+            //      textAlign = androidx.compose.ui.text.style.TextAlign.Center)
+        }
+    }
+}
+
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewAnalyticsDashboardScreen() {
+    MaterialTheme {
+        AnalyticsDashboardScreen(viewModel = AnalyticsDashboardViewModel())
+    }
+}
+package com.example.rooster.admin.analytics
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import java.text.DecimalFormat
+import java.util.Date
+
+// --- Data Classes ---
+// Using Maps and Any for flexibility, mirroring Python's dictionary structure.
+// For a production app, more specific data classes would be better.
+
+data class KpiData(val metrics: Map<String, Any>)
+data class UserBehaviorData(val metrics: Map<String, Any>)
+data class RevenueTrackingData(val metrics: Map<String, Any>)
+data class SystemPerformanceSummaryData(val metrics: Map<String, Any>)
+data class ContentEngagementData(val metrics: Map<String, Any>)
+data class TimeSeriesDataPoint(val date: String, val value: Number) // For revenue or user counts
+data class TimeSeriesChartData(val name: String, val points: List<TimeSeriesDataPoint>)
+
+
+// --- ViewModel ---
+class AnalyticsDashboardViewModel : ViewModel() {
+    private val _kpis = MutableStateFlow<KpiData?>(null)
+    val kpis: StateFlow<KpiData?> = _kpis
+
+    private val _userBehavior = MutableStateFlow<UserBehaviorData?>(null)
+    val userBehavior: StateFlow<UserBehaviorData?> = _userBehavior
+
+    private val _revenueTracking = MutableStateFlow<RevenueTrackingData?>(null)
+    val revenueTracking: StateFlow<RevenueTrackingData?> = _revenueTracking
+
+    private val _systemPerformance = MutableStateFlow<SystemPerformanceSummaryData?>(null)
+    val systemPerformance: StateFlow<SystemPerformanceSummaryData?> = _systemPerformance
+
+    private val _contentEngagement = MutableStateFlow<ContentEngagementData?>(null)
+    val contentEngagement: StateFlow<ContentEngagementData?> = _contentEngagement
+
+    private val _revenueOverTime = MutableStateFlow<TimeSeriesChartData?>(null)
+    val revenueOverTime: StateFlow<TimeSeriesChartData?> = _revenueOverTime
+
+    private val _newUsersOverTime = MutableStateFlow<TimeSeriesChartData?>(null)
+    val newUsersOverTime: StateFlow<TimeSeriesChartData?> = _newUsersOverTime
+
+    init {
+        loadMockMetrics()
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun loadMockMetrics() {
+        // Mock data similar to Python script
+        _kpis.value = KpiData(mapOf(
+            "total_users" to 15230,
+            "active_users_monthly" to 8500,
+            "active_users_daily" to 1200,
+            "new_signups_last_30_days" to 750,
+            "user_retention_rate" to "65%"
+        ))
+
+        _userBehavior.value = UserBehaviorData(mapOf(
+            "average_session_duration" to "15 minutes",
+            "pages_per_session" to 5.2,
+            "most_visited_feature" to "Veterinary Consultation",
+            "feature_engagement_rate" to mapOf(
+                "Consultations" to "40%",
+                "Marketplace" to "30%",
+                "Educational Content" to "25%",
+                "Forum" to "15%"
+            ),
+            "user_demographics_summary" to mapOf(
+                "top_country" to "USA (60%)",
+                "user_types" to "Farmers (70%), Veterinarians (30%)"
+            )
+        ))
+
+        _revenueTracking.value = RevenueTrackingData(mapOf(
+            "total_revenue_mtd" to 12500.75,
+            "total_revenue_ytd" to 150200.50,
+            "average_revenue_per_user_arpu" to 9.86,
+            "revenue_by_source" to mapOf(
+                "Consultation Fees" to 75000.00,
+                "Marketplace Commissions" to 60200.50,
+                "Subscription Fees" to 15000.00
+            ),
+            "recent_transactions_count_last_24h" to 85
+        ))
+
+        _systemPerformance.value = SystemPerformanceSummaryData(mapOf(
+            "overall_uptime" to "99.98%",
+            "average_api_response_time" to "140ms",
+            "critical_errors_last_24h" to 2
+        ))
+
+        _contentEngagement.value = ContentEngagementData(mapOf(
+            "new_articles_published_last_30d" to 25,
+            "article_views_last_30d" to 15000,
+            "average_time_on_page_articles" to "3 min 45 sec",
+            "most_popular_article_id" to "article_vet_health_basics"
+        ))
+
+        // Mock time series data
+        val today = java.util.Calendar.getInstance()
+        val revenuePoints = (0..29).map { i ->
+            val day = today.clone() as java.util.Calendar
+            day.add(java.util.Calendar.DATE, -i)
+            TimeSeriesDataPoint(
+                date = "${day.get(java.util.Calendar.YEAR)}-${day.get(java.util.Calendar.MONTH) + 1}-${day.get(java.util.Calendar.DAY_OF_MONTH)}",
+                value = (300..800).random().toDouble()
+            )
+        }.reversed()
+        _revenueOverTime.value = TimeSeriesChartData("Revenue Over Time (Daily)", revenuePoints)
+
+        val newUsersPoints = (0..29).map { i ->
+            val day = today.clone() as java.util.Calendar
+            day.add(java.util.Calendar.DATE, -i)
+            TimeSeriesDataPoint(
+                date = "${day.get(java.util.Calendar.YEAR)}-${day.get(java.util.Calendar.MONTH) + 1}-${day.get(java.util.Calendar.DAY_OF_MONTH)}",
+                value = (10..50).random()
+            )
+        }.reversed()
+        _newUsersOverTime.value = TimeSeriesChartData("New Users Over Time (Daily)", newUsersPoints)
+    }
+}
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AnalyticsDashboardScreen(viewModel: AnalyticsDashboardViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val kpis by viewModel.kpis.collectAsState()
+    val userBehavior by viewModel.userBehavior.collectAsState()
+    val revenueTracking by viewModel.revenueTracking.collectAsState()
+    val systemPerformance by viewModel.systemPerformance.collectAsState()
+    val contentEngagement by viewModel.contentEngagement.collectAsState()
+    val revenueOverTime by viewModel.revenueOverTime.collectAsState()
+    val newUsersOverTime by viewModel.newUsersOverTime.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Analytics Dashboard") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Yellow) // Example
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(modifier = Modifier.padding(paddingValues).padding(16.dp)) {
+            kpis?.let { data -> item { AnalyticsSectionCard("Key Performance Indicators", data.metrics) } }
+            userBehavior?.let { data -> item { AnalyticsSectionCard("User Behavior", data.metrics) } }
+            revenueTracking?.let { data -> item { AnalyticsSectionCard("Revenue Tracking", data.metrics) } }
+            systemPerformance?.let { data -> item { AnalyticsSectionCard("System Performance Summary", data.metrics) } }
+            contentEngagement?.let { data -> item { AnalyticsSectionCard("Content Engagement", data.metrics) } }
+
+            revenueOverTime?.let { data -> item { TimeSeriesSection("Revenue Over Last 30 Days (Sample)", data.points) } }
+            newUsersOverTime?.let { data -> item { TimeSeriesSection("New Users Over Last 30 Days (Sample)", data.points) } }
+        }
+    }
+}
+
+@Composable
+fun AnalyticsSectionCard(title: String, metrics: Map<String, Any>) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(title, style = MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(bottom = 8.dp))
+            DisplayMetrics(metrics)
+        }
+    }
+}
+
+@Composable
+fun DisplayMetrics(metrics: Map<String, Any>, indentLevel: Int = 0) {
+    val indent = "  ".repeat(indentLevel)
+    val decimalFormat = DecimalFormat("#,##0.00")
+
+    metrics.forEach { (key, value) ->
+        val displayKey = key.replace("_", " ").replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
+        when (value) {
+            is Map<*, *> -> {
+                Text("$indent$displayKey:")
+                DisplayMetrics(value as Map<String, Any>, indentLevel + 1)
+            }
+            is Double -> Text("$indent$displayKey: $${decimalFormat.format(value)}")
+            is Number -> Text("$indent$displayKey: $value")
+            else -> Text("$indent$displayKey: $value")
+        }
+    }
+}
+
+@Composable
+fun TimeSeriesSection(title: String, dataPoints: List<TimeSeriesDataPoint>) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(title, style = MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(bottom = 8.dp))
+            // Displaying top 5 for brevity, similar to Python's print output
+            dataPoints.take(5).forEach { point ->
+                Text("  Date: ${point.date}, Value: ${point.value}")
+            }
+            if (dataPoints.size > 5) {
+                Text("  ... and more data points")
+            }
+            // Placeholder for chart:
+            // Text("Chart would be displayed here using MPAndroidChart or similar.",
+            //      modifier = Modifier.padding(vertical = 8.dp).fillMaxWidth(),
+            //      textAlign = androidx.compose.ui.text.style.TextAlign.Center)
+        }
+    }
+}
+
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewAnalyticsDashboardScreen() {
+    MaterialTheme {
+        AnalyticsDashboardScreen(viewModel = AnalyticsDashboardViewModel())
+    }
+}

--- a/app/src/main/java/com/example/rooster/admin/contentmoderation/ContentModerationScreen.kt
+++ b/app/src/main/java/com/example/rooster/admin/contentmoderation/ContentModerationScreen.kt
@@ -1,0 +1,493 @@
+package com.example.rooster.admin.contentmoderation
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+// --- Data Classes ---
+data class ReportedContent(
+    val reportId: String,
+    val contentId: String,
+    val contentType: String,
+    val reporterUserId: String,
+    val reportedUserId: String,
+    val reason: String,
+    val timestamp: Date,
+    var status: String, // pending_review, approved, rejected, action_taken
+    val contentPreview: String,
+    var moderatorNotes: String? = null,
+    var actionTaken: String? = null,
+    var moderatorId: String? = null,
+    var reviewTimestamp: Date? = null
+) {
+    fun getFormattedTimestamp(): String =
+        SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(timestamp)
+
+    fun getFormattedReviewTimestamp(): String? =
+        reviewTimestamp?.let { SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(it) }
+}
+
+// --- ViewModel ---
+class ContentModerationViewModel : ViewModel() {
+    private val _reports = MutableStateFlow<List<ReportedContent>>(emptyList())
+    val reports: StateFlow<List<ReportedContent>> = _reports
+
+    val pendingReports: StateFlow<List<ReportedContent>> = MutableStateFlow(emptyList()) // Derived flow
+
+    init {
+        loadMockContent()
+        // This is a simple way to create a derived flow. For more complex scenarios,
+        // you might use .map or .combine on the original _reports flow.
+        _reports.value.filter { it.status == "pending_review" }.also {
+            (pendingReports as MutableStateFlow).value = it
+        }
+    }
+
+    private fun loadMockContent() {
+        val now = System.currentTimeMillis()
+        _reports.value = listOf(
+            ReportedContent(
+                "report001", "post123", "forum_post", "user002", "user003",
+                "Spam and unsolicited advertising.", Date(now - 3600000), "pending_review",
+                "Check out my amazing new product at spam.com!"
+            ),
+            ReportedContent(
+                "report002", "comment456", "article_comment", "user001", "user004",
+                "Offensive language.", Date(now - 3 * 3600000), "pending_review",
+                "This article is terrible and the author is an idiot."
+            ),
+            ReportedContent(
+                "report003", "listing789", "marketplace_listing", "user003", "user002",
+                "Misleading product description.", Date(now - 24 * 3600000), "action_taken",
+                "Miracle cure for all animal diseases! Guaranteed!",
+                moderatorNotes = "Removed listing due to false claims. Warned user.",
+                actionTaken = "listing_removed", moderatorId = "admin_mod", reviewTimestamp = Date(now - 12 * 3600000)
+            )
+        )
+        updatePendingReports()
+    }
+
+    private fun updatePendingReports() {
+        (pendingReports as MutableStateFlow).value = _reports.value.filter { it.status == "pending_review" }
+    }
+
+    fun reviewContent(reportId: String, action: String, moderatorId: String, notes: String) {
+        _reports.update { currentReports ->
+            currentReports.map { report ->
+                if (report.reportId == reportId) {
+                    report.copy(
+                        status = "action_taken",
+                        actionTaken = action,
+                        moderatorId = moderatorId,
+                        moderatorNotes = notes,
+                        reviewTimestamp = Date()
+                    )
+                } else report
+            }
+        }
+        updatePendingReports()
+    }
+}
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ContentModerationScreen(viewModel: ContentModerationViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val allReports by viewModel.reports.collectAsState()
+    // val pendingReports by viewModel.pendingReports.collectAsState() // Use this if you prefer separate state
+
+    // For this example, we'll filter directly from allReports for simplicity in tabs or sections
+    val pendingReportsList = allReports.filter { it.status == "pending_review" }
+    val reviewedReportsList = allReports.filter { it.status != "pending_review" }
+
+
+    var showDialog by remember { mutableStateOf(false) }
+    var selectedReport by remember { mutableStateOf<ReportedContent?>(null) }
+    var actionNotes by remember { mutableStateOf("") }
+    var actionType by remember { mutableStateOf("") } // e.g. "remove_content", "warn_user"
+
+    val possibleActions = listOf("approve_content", "remove_content", "warn_user", "ban_user", "reject_report")
+
+
+    if (showDialog && selectedReport != null) {
+        AlertDialog(
+            onDismissRequest = { showDialog = false },
+            title = { Text("Review Report: ${selectedReport?.reportId}") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text("Content: \"${selectedReport?.contentPreview}\"", style = MaterialTheme.typography.bodyMedium)
+                    Text("Reason: ${selectedReport?.reason}", style = MaterialTheme.typography.bodySmall)
+                    OutlinedTextField(
+                        value = actionType,
+                        onValueChange = { actionType = it },
+                        label = { Text("Action Type (e.g., remove_content)") }
+                        // Consider a DropdownMenu for predefined actions
+                    )
+                    OutlinedTextField(
+                        value = actionNotes,
+                        onValueChange = { actionNotes = it },
+                        label = { Text("Moderator Notes") },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            },
+            confirmButton = {
+                Button(onClick = {
+                    selectedReport?.let {
+                        viewModel.reviewContent(it.reportId, actionType, "current_admin_user", actionNotes)
+                    }
+                    showDialog = false
+                    actionNotes = ""
+                    actionType = ""
+                }) { Text("Submit Review") }
+            },
+            dismissButton = { Button(onClick = { showDialog = false }) { Text("Cancel") } }
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Content Moderation") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Red) // Example
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(modifier = Modifier.padding(paddingValues).padding(16.dp)) {
+            item {
+                Text("Pending Reports", style = MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(bottom = 8.dp))
+            }
+            if (pendingReportsList.isEmpty()) {
+                item { Text("No pending reports.") }
+            } else {
+                items(pendingReportsList) { report ->
+                    ReportCard(report) {
+                        selectedReport = it
+                        showDialog = true
+                    }
+                }
+            }
+
+            item {
+                Text("Reviewed Reports", style = MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(top = 16.dp, bottom = 8.dp))
+            }
+            if (reviewedReportsList.isEmpty()) {
+                item { Text("No reviewed reports.") }
+            } else {
+                items(reviewedReportsList) { report ->
+                    ReportCard(report, isReviewed = true) {} // No action on click for reviewed for now
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ReportCard(report: ReportedContent, isReviewed: Boolean = false, onReviewClick: (ReportedContent) -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Report ID: ${report.reportId}", style = MaterialTheme.typography.titleMedium)
+            Text("Content ID: ${report.contentId} (${report.contentType})")
+            Text("Preview: \"${report.contentPreview}\"")
+            Text("Reason: ${report.reason}")
+            Text("Reported by: ${report.reporterUserId} against ${report.reportedUserId}")
+            Text("Reported at: ${report.getFormattedTimestamp()}")
+            Text("Status: ${report.status}", color = if (report.status == "pending_review") Color.Blue else Color.DarkGray)
+
+            if (report.status != "pending_review") {
+                Text("Action Taken: ${report.actionTaken ?: "N/A"}")
+                Text("Moderator: ${report.moderatorId ?: "N/A"}")
+                Text("Moderator Notes: ${report.moderatorNotes ?: "N/A"}")
+                report.getFormattedReviewTimestamp()?.let { Text("Reviewed At: $it") }
+            }
+
+            if (!isReviewed && report.status == "pending_review") {
+                Spacer(Modifier.height(8.dp))
+                Button(onClick = { onReviewClick(report) }, modifier = Modifier.align(Alignment.End)) {
+                    Text("Review Report")
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewContentModerationScreen() {
+    MaterialTheme {
+        ContentModerationScreen(viewModel = ContentModerationViewModel())
+    }
+}
+package com.example.rooster.admin.contentmoderation
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import androidx.compose.ui.Alignment
+
+// --- Data Classes ---
+data class ReportedContent(
+    val reportId: String,
+    val contentId: String,
+    val contentType: String,
+    val reporterUserId: String,
+    val reportedUserId: String,
+    val reason: String,
+    val timestamp: Date,
+    var status: String, // pending_review, approved, rejected, action_taken
+    val contentPreview: String,
+    var moderatorNotes: String? = null,
+    var actionTaken: String? = null,
+    var moderatorId: String? = null,
+    var reviewTimestamp: Date? = null
+) {
+    fun getFormattedTimestamp(): String =
+        SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(timestamp)
+
+    fun getFormattedReviewTimestamp(): String? =
+        reviewTimestamp?.let { SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(it) }
+}
+
+// --- ViewModel ---
+class ContentModerationViewModel : ViewModel() {
+    private val _reports = MutableStateFlow<List<ReportedContent>>(emptyList())
+    val reports: StateFlow<List<ReportedContent>> = _reports
+
+    // No need for a separate pendingReports StateFlow if we filter in the Composable or derive it there.
+    // However, if complex logic depended on it, it could be useful.
+    // val pendingReports: StateFlow<List<ReportedContent>> = _reports.map { it.filter { report -> report.status == "pending_review" } }.stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+
+    init {
+        loadMockContent()
+    }
+
+    private fun loadMockContent() {
+        val now = System.currentTimeMillis()
+        _reports.value = listOf(
+            ReportedContent(
+                "report001", "post123", "forum_post", "user002", "user003",
+                "Spam and unsolicited advertising.", Date(now - 3600000), "pending_review",
+                "Check out my amazing new product at spam.com!"
+            ),
+            ReportedContent(
+                "report002", "comment456", "article_comment", "user001", "user004",
+                "Offensive language.", Date(now - 3 * 3600000), "pending_review",
+                "This article is terrible and the author is an idiot."
+            ),
+            ReportedContent(
+                "report003", "listing789", "marketplace_listing", "user003", "user002",
+                "Misleading product description.", Date(now - 24 * 3600000), "action_taken",
+                "Miracle cure for all animal diseases! Guaranteed!",
+                moderatorNotes = "Removed listing due to false claims. Warned user.",
+                actionTaken = "listing_removed", moderatorId = "admin_mod", reviewTimestamp = Date(now - 12 * 3600000)
+            )
+        )
+    }
+
+    fun reviewContent(reportId: String, action: String, moderatorId: String, notes: String) {
+        _reports.update { currentReports ->
+            currentReports.map { report ->
+                if (report.reportId == reportId) {
+                    report.copy(
+                        status = "action_taken",
+                        actionTaken = action,
+                        moderatorId = moderatorId,
+                        moderatorNotes = notes,
+                        reviewTimestamp = Date()
+                    )
+                } else report
+            }
+        }
+    }
+}
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ContentModerationScreen(viewModel: ContentModerationViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val allReports by viewModel.reports.collectAsState()
+
+    val pendingReportsList = allReports.filter { it.status == "pending_review" }
+    val reviewedReportsList = allReports.filter { it.status != "pending_review" }
+
+    var showDialog by remember { mutableStateOf(false) }
+    var selectedReport by remember { mutableStateOf<ReportedContent?>(null) }
+    var actionNotes by remember { mutableStateOf("") }
+    var actionTypeInput by remember { mutableStateOf("") } // For TextField
+    var expanded by remember { mutableStateOf(false) } // For Dropdown
+
+
+    val possibleActions = listOf("approve_content", "remove_content", "warn_user", "ban_user", "reject_report")
+
+
+    if (showDialog && selectedReport != null) {
+        AlertDialog(
+            onDismissRequest = { showDialog = false },
+            title = { Text("Review Report: ${selectedReport?.reportId}") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text("Content: \"${selectedReport?.contentPreview}\"", style = MaterialTheme.typography.bodyMedium)
+                    Text("Reason: ${selectedReport?.reason}", style = MaterialTheme.typography.bodySmall)
+
+                    ExposedDropdownMenuBox(
+                        expanded = expanded,
+                        onExpandedChange = { expanded = !expanded }
+                    ) {
+                        OutlinedTextField(
+                            value = actionTypeInput,
+                            onValueChange = {}, // Not directly changed, selected from dropdown
+                            readOnly = true,
+                            label = { Text("Select Action") },
+                            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                            modifier = Modifier.menuAnchor().fillMaxWidth()
+                        )
+                        ExposedDropdownMenu(
+                            expanded = expanded,
+                            onDismissRequest = { expanded = false }
+                        ) {
+                            possibleActions.forEach { action ->
+                                DropdownMenuItem(
+                                    text = { Text(action) },
+                                    onClick = {
+                                        actionTypeInput = action
+                                        expanded = false
+                                    }
+                                )
+                            }
+                        }
+                    }
+                    OutlinedTextField(
+                        value = actionNotes,
+                        onValueChange = { actionNotes = it },
+                        label = { Text("Moderator Notes") },
+                        modifier = Modifier.fillMaxWidth(),
+                        minLines = 2
+                    )
+                }
+            },
+            confirmButton = {
+                Button(onClick = {
+                    selectedReport?.let {
+                        viewModel.reviewContent(it.reportId, actionTypeInput, "current_admin_user", actionNotes)
+                    }
+                    showDialog = false
+                    actionNotes = ""
+                    actionTypeInput = ""
+                }, enabled = actionTypeInput.isNotBlank()) { Text("Submit Review") }
+            },
+            dismissButton = { Button(onClick = { showDialog = false; actionNotes = ""; actionTypeInput = "" }) { Text("Cancel") } }
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Content Moderation") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Magenta) // Example color
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(modifier = Modifier.padding(paddingValues).padding(16.dp)) {
+            item {
+                Text("Pending Reports", style = MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(bottom = 8.dp))
+            }
+            if (pendingReportsList.isEmpty()) {
+                item { Text("No pending reports.") }
+            } else {
+                items(pendingReportsList) { report ->
+                    ReportCard(report) {
+                        selectedReport = it
+                        actionTypeInput = "" // Reset for new dialog
+                        actionNotes = ""
+                        showDialog = true
+                    }
+                }
+            }
+
+            item {
+                Text("Reviewed Reports", style = MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(top = 16.dp, bottom = 8.dp))
+            }
+            if (reviewedReportsList.isEmpty()) {
+                item { Text("No reviewed reports.") }
+            } else {
+                items(reviewedReportsList) { report ->
+                    ReportCard(report, isReviewed = true) {} // No action on click for reviewed for now
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ReportCard(report: ReportedContent, isReviewed: Boolean = false, onReviewClick: (ReportedContent) -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text("Report ID: ${report.reportId}", style = MaterialTheme.typography.titleSmall)
+            Text("Content ID: ${report.contentId} (${report.contentType})", style = MaterialTheme.typography.bodyMedium)
+            Text("Preview: \"${report.contentPreview}\"", style = MaterialTheme.typography.bodyMedium)
+            Text("Reason: ${report.reason}", style = MaterialTheme.typography.bodyMedium)
+            Text("Reported by: ${report.reporterUserId} against ${report.reportedUserId}", style = MaterialTheme.typography.bodySmall)
+            Text("Reported at: ${report.getFormattedTimestamp()}", style = MaterialTheme.typography.bodySmall)
+            Text("Status: ${report.status}", color = if (report.status == "pending_review") MaterialTheme.colorScheme.primary else Color.DarkGray, style = MaterialTheme.typography.labelMedium)
+
+            if (report.status != "pending_review") {
+                Text("Action Taken: ${report.actionTaken ?: "N/A"}", style = MaterialTheme.typography.bodySmall)
+                Text("Moderator: ${report.moderatorId ?: "N/A"}", style = MaterialTheme.typography.bodySmall)
+                Text("Moderator Notes: ${report.moderatorNotes ?: "N/A"}", style = MaterialTheme.typography.bodySmall)
+                report.getFormattedReviewTimestamp()?.let { Text("Reviewed At: $it", style = MaterialTheme.typography.bodySmall) }
+            }
+
+            if (!isReviewed && report.status == "pending_review") {
+                Spacer(Modifier.height(8.dp))
+                Button(onClick = { onReviewClick(report) }, modifier = Modifier.align(Alignment.End)) {
+                    Text("Review Report")
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewContentModerationScreen() {
+    MaterialTheme {
+        ContentModerationScreen(viewModel = ContentModerationViewModel())
+    }
+}

--- a/app/src/main/java/com/example/rooster/admin/featureflags/FeatureFlagScreen.kt
+++ b/app/src/main/java/com/example/rooster/admin/featureflags/FeatureFlagScreen.kt
@@ -1,0 +1,550 @@
+package com.example.rooster.admin.featureflags
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+// --- Data Classes ---
+data class FeatureFlag(
+    val name: String, // Unique identifier
+    var description: String,
+    var isActive: Boolean,
+    var rolloutPercentage: Int, // 0-100
+    var targetUserSegment: String,
+    val createdAt: Date,
+    var updatedAt: Date,
+    val createdBy: String
+) {
+    private fun formatDate(date: Date): String =
+        SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(date)
+
+    val formattedCreatedAt: String get() = formatDate(createdAt)
+    val formattedUpdatedAt: String get() = formatDate(updatedAt)
+}
+
+// --- ViewModel ---
+class FeatureFlagViewModel : ViewModel() {
+    private val _featureFlags = MutableStateFlow<List<FeatureFlag>>(emptyList())
+    val featureFlags: StateFlow<List<FeatureFlag>> = _featureFlags
+
+    init {
+        loadMockFlags()
+    }
+
+    private fun loadMockFlags() {
+        val now = System.currentTimeMillis()
+        _featureFlags.value = listOf(
+            FeatureFlag("new_telemedicine_interface", "Enable the redesigned telemedicine interface for video consultations.", false, 0, "all", Date(now - 10 * 86400000L), Date(now - 1 * 86400000L), "admin_jane"),
+            FeatureFlag("ai_diagnosis_assistant_beta", "Enable the AI-powered diagnosis assistant (Beta).", true, 10, "veterinarians_approved_beta", Date(now - 30 * 86400000L), Date(now - 5 * 3600000L), "admin_john"),
+            FeatureFlag("marketplace_commission_increase_test", "A/B Test: Increase marketplace commission from 5% to 7% for a subset of new sellers.", true, 5, "new_sellers_last_7_days", Date(now - 3 * 86400000L), Date(now - 1 * 86400000L), "admin_jane"),
+            FeatureFlag("disable_legacy_reporting", "Disable the old reporting system for users who have migrated to the new one.", false, 0, "migrated_users_group_A", Date(now - 5 * 86400000L), Date(now - 5 * 86400000L), "admin_john")
+        )
+    }
+
+    fun createFlag(name: String, description: String, targetSegment: String, createdBy: String) {
+        if (_featureFlags.value.any { it.name == name }) {
+            // Handle error: flag already exists
+            return
+        }
+        val newFlag = FeatureFlag(name, description, false, 0, targetSegment, Date(), Date(), createdBy)
+        _featureFlags.update { it + newFlag }
+    }
+
+    fun updateFlagStatus(name: String, isActive: Boolean) {
+        _featureFlags.update { flags ->
+            flags.map { if (it.name == name) it.copy(isActive = isActive, updatedAt = Date()) else it }
+        }
+    }
+
+    fun updateRolloutPercentage(name: String, percentage: Int) {
+        if (percentage < 0 || percentage > 100) return // Basic validation
+        _featureFlags.update { flags ->
+            flags.map { if (it.name == name) it.copy(rolloutPercentage = percentage, updatedAt = Date()) else it }
+        }
+    }
+
+    fun updateTargetSegment(name: String, segment: String) {
+        _featureFlags.update { flags ->
+            flags.map { if (it.name == name) it.copy(targetUserSegment = segment, updatedAt = Date()) else it }
+        }
+    }
+
+    fun updateDescription(name: String, description: String) {
+        _featureFlags.update { flags ->
+            flags.map { if (it.name == name) it.copy(description = description, updatedAt = Date()) else it }
+        }
+    }
+
+    fun deleteFlag(name: String) {
+        _featureFlags.update { flags -> flags.filterNot { it.name == name } }
+    }
+}
+
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FeatureFlagScreen(viewModel: FeatureFlagViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val flags by viewModel.featureFlags.collectAsState()
+    var showEditDialog by remember { mutableStateOf(false) }
+    var showCreateDialog by remember { mutableStateOf(false) }
+    var currentEditingFlag by remember { mutableStateOf<FeatureFlag?>(null) }
+
+    // State for Create Dialog
+    var newFlagName by remember { mutableStateOf("") }
+    var newFlagDesc by remember { mutableStateOf("") }
+    var newFlagSegment by remember { mutableStateOf("") }
+
+
+    if (showCreateDialog) {
+        AlertDialog(
+            onDismissRequest = { showCreateDialog = false },
+            title = { Text("Create New Feature Flag") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedTextField(value = newFlagName, onValueChange = { newFlagName = it }, label = { Text("Flag Name (ID)") })
+                    OutlinedTextField(value = newFlagDesc, onValueChange = { newFlagDesc = it }, label = { Text("Description") })
+                    OutlinedTextField(value = newFlagSegment, onValueChange = { newFlagSegment = it }, label = { Text("Target Segment") })
+                }
+            },
+            confirmButton = {
+                Button(onClick = {
+                    if (newFlagName.isNotBlank() && newFlagDesc.isNotBlank() && newFlagSegment.isNotBlank()) {
+                        viewModel.createFlag(newFlagName, newFlagDesc, newFlagSegment, "admin_user")
+                        showCreateDialog = false
+                        newFlagName = ""; newFlagDesc = ""; newFlagSegment = ""
+                    }
+                }) { Text("Create") }
+            },
+            dismissButton = { Button(onClick = { showCreateDialog = false }) { Text("Cancel") } }
+        )
+    }
+
+    currentEditingFlag?.let { flag ->
+        if (showEditDialog) {
+            EditFeatureFlagDialog(
+                flag = flag,
+                viewModel = viewModel,
+                onDismiss = { showEditDialog = false }
+            )
+        }
+    }
+
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Feature Flag Management") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Green) // Example
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { showCreateDialog = true }) {
+                Icon(Icons.Filled.Add, "Create new flag")
+            }
+        }
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = Modifier.padding(paddingValues).padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            items(flags) { flag ->
+                FeatureFlagCard(
+                    flag = flag,
+                    onEditClick = {
+                        currentEditingFlag = it
+                        showEditDialog = true
+                    },
+                    onDeleteClick = { viewModel.deleteFlag(it.name) },
+                    onToggleStatus = { viewModel.updateFlagStatus(flag.name, !flag.isActive) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun FeatureFlagCard(
+    flag: FeatureFlag,
+    onEditClick: (FeatureFlag) -> Unit,
+    onDeleteClick: (FeatureFlag) -> Unit,
+    onToggleStatus: () -> Unit
+) {
+    Card(elevation = CardDefaults.cardElevation(defaultElevation = 2.dp), modifier = Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp)) {
+            Text(flag.name, style = MaterialTheme.typography.titleLarge)
+            Text("Description: ${flag.description}", style = MaterialTheme.typography.bodyMedium)
+            Text("Target Segment: ${flag.targetUserSegment}", style = MaterialTheme.typography.bodySmall)
+            Text("Rollout: ${flag.rolloutPercentage}%", style = MaterialTheme.typography.bodySmall)
+            Text("Created By: ${flag.createdBy} at ${flag.formattedCreatedAt}", style = MaterialTheme.typography.bodySmall)
+            Text("Last Updated: ${flag.formattedUpdatedAt}", style = MaterialTheme.typography.bodySmall)
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(top = 8.dp)
+            ) {
+                Text("Active: ")
+                Switch(checked = flag.isActive, onCheckedChange = { onToggleStatus() })
+                Spacer(Modifier.weight(1f))
+                IconButton(onClick = { onEditClick(flag) }) {
+                    Icon(Icons.Filled.Edit, "Edit Flag")
+                }
+                IconButton(onClick = { onDeleteClick(flag) }) {
+                    Icon(Icons.Filled.Delete, "Delete Flag")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun EditFeatureFlagDialog(
+    flag: FeatureFlag,
+    viewModel: FeatureFlagViewModel,
+    onDismiss: () -> Unit
+) {
+    var description by remember { mutableStateOf(flag.description) }
+    var rolloutPercentage by remember { mutableStateOf(flag.rolloutPercentage.toString()) }
+    var targetSegment by remember { mutableStateOf(flag.targetUserSegment) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Edit: ${flag.name}") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(value = description, onValueChange = { description = it }, label = { Text("Description") })
+                OutlinedTextField(
+                    value = rolloutPercentage,
+                    onValueChange = { rolloutPercentage = it.filter { char -> char.isDigit() } },
+                    label = { Text("Rollout % (0-100)") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+                )
+                OutlinedTextField(value = targetSegment, onValueChange = { targetSegment = it }, label = { Text("Target Segment") })
+            }
+        },
+        confirmButton = {
+            Button(onClick = {
+                viewModel.updateDescription(flag.name, description)
+                rolloutPercentage.toIntOrNull()?.let { percent ->
+                     if(percent in 0..100) viewModel.updateRolloutPercentage(flag.name, percent)
+                }
+                viewModel.updateTargetSegment(flag.name, targetSegment)
+                onDismiss()
+            }) { Text("Save Changes") }
+        },
+        dismissButton = { Button(onClick = onDismiss) { Text("Cancel") } }
+    )
+}
+
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewFeatureFlagScreen() {
+    MaterialTheme {
+        FeatureFlagScreen(viewModel = FeatureFlagViewModel())
+    }
+}
+package com.example.rooster.admin.featureflags
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+// --- Data Classes ---
+data class FeatureFlag(
+    val name: String, // Unique identifier
+    var description: String,
+    var isActive: Boolean,
+    var rolloutPercentage: Int, // 0-100
+    var targetUserSegment: String,
+    val createdAt: Date,
+    var updatedAt: Date,
+    val createdBy: String
+) {
+    private fun formatDate(date: Date): String =
+        SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(date)
+
+    val formattedCreatedAt: String get() = formatDate(createdAt)
+    val formattedUpdatedAt: String get() = formatDate(updatedAt)
+}
+
+// --- ViewModel ---
+class FeatureFlagViewModel : ViewModel() {
+    private val _featureFlags = MutableStateFlow<List<FeatureFlag>>(emptyList())
+    val featureFlags: StateFlow<List<FeatureFlag>> = _featureFlags
+
+    init {
+        loadMockFlags()
+    }
+
+    private fun loadMockFlags() {
+        val now = System.currentTimeMillis()
+        _featureFlags.value = listOf(
+            FeatureFlag("new_telemedicine_interface", "Enable the redesigned telemedicine interface for video consultations.", false, 0, "all", Date(now - 10 * 86400000L), Date(now - 1 * 86400000L), "admin_jane"),
+            FeatureFlag("ai_diagnosis_assistant_beta", "Enable the AI-powered diagnosis assistant (Beta).", true, 10, "veterinarians_approved_beta", Date(now - 30 * 86400000L), Date(now - 5 * 3600000L), "admin_john"),
+            FeatureFlag("marketplace_commission_increase_test", "A/B Test: Increase marketplace commission from 5% to 7% for a subset of new sellers.", true, 5, "new_sellers_last_7_days", Date(now - 3 * 86400000L), Date(now - 1 * 86400000L), "admin_jane"),
+            FeatureFlag("disable_legacy_reporting", "Disable the old reporting system for users who have migrated to the new one.", false, 0, "migrated_users_group_A", Date(now - 5 * 86400000L), Date(now - 5 * 86400000L), "admin_john")
+        ).sortedBy { it.name }
+    }
+
+    fun createFlag(name: String, description: String, targetSegment: String, createdBy: String) {
+        if (_featureFlags.value.any { it.name == name }) {
+            // Ideally, show an error message to the user
+            println("Error: Feature flag '$name' already exists.")
+            return
+        }
+        val newFlag = FeatureFlag(name, description, false, 0, targetSegment, Date(), Date(), createdBy)
+        _featureFlags.update { (it + newFlag).sortedBy { f -> f.name } }
+    }
+
+    fun updateFlagStatus(name: String, isActive: Boolean) {
+        _featureFlags.update { flags ->
+            flags.map { if (it.name == name) it.copy(isActive = isActive, updatedAt = Date()) else it }
+        }
+    }
+
+    fun updateRolloutPercentage(name: String, percentage: Int) {
+        if (percentage < 0 || percentage > 100) {
+             println("Error: Percentage must be between 0 and 100.")
+            return
+        }
+        _featureFlags.update { flags ->
+            flags.map { if (it.name == name) it.copy(rolloutPercentage = percentage, updatedAt = Date()) else it }
+        }
+    }
+
+    fun updateTargetSegment(name: String, segment: String) {
+        _featureFlags.update { flags ->
+            flags.map { if (it.name == name) it.copy(targetUserSegment = segment, updatedAt = Date()) else it }
+        }
+    }
+
+    fun updateDescription(name: String, description: String) {
+        _featureFlags.update { flags ->
+            flags.map { if (it.name == name) it.copy(description = description, updatedAt = Date()) else it }
+        }
+    }
+
+    fun deleteFlag(name: String) {
+        _featureFlags.update { flags -> flags.filterNot { it.name == name } }
+    }
+}
+
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FeatureFlagScreen(viewModel: FeatureFlagViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val flags by viewModel.featureFlags.collectAsState()
+    var showEditDialog by remember { mutableStateOf(false) }
+    var showCreateDialog by remember { mutableStateOf(false) }
+    var currentEditingFlag by remember { mutableStateOf<FeatureFlag?>(null) }
+
+    // State for Create Dialog
+    var newFlagName by remember { mutableStateOf("") }
+    var newFlagDesc by remember { mutableStateOf("") }
+    var newFlagSegment by remember { mutableStateOf("") }
+
+
+    if (showCreateDialog) {
+        AlertDialog(
+            onDismissRequest = { showCreateDialog = false },
+            title = { Text("Create New Feature Flag") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedTextField(value = newFlagName, onValueChange = { newFlagName = it }, label = { Text("Flag Name (ID)") }, singleLine = true)
+                    OutlinedTextField(value = newFlagDesc, onValueChange = { newFlagDesc = it }, label = { Text("Description") })
+                    OutlinedTextField(value = newFlagSegment, onValueChange = { newFlagSegment = it }, label = { Text("Target Segment") }, singleLine = true)
+                }
+            },
+            confirmButton = {
+                Button(onClick = {
+                    if (newFlagName.isNotBlank() && newFlagDesc.isNotBlank() && newFlagSegment.isNotBlank()) {
+                        viewModel.createFlag(newFlagName.trim(), newFlagDesc.trim(), newFlagSegment.trim(), "admin_compose_ui")
+                        showCreateDialog = false
+                        newFlagName = ""; newFlagDesc = ""; newFlagSegment = ""
+                    }
+                }) { Text("Create") }
+            },
+            dismissButton = { Button(onClick = { showCreateDialog = false }) { Text("Cancel") } }
+        )
+    }
+
+    currentEditingFlag?.let { flag ->
+        if (showEditDialog) {
+            EditFeatureFlagDialog(
+                flag = flag,
+                viewModel = viewModel,
+                onDismiss = { showEditDialog = false; currentEditingFlag = null }
+            )
+        }
+    }
+
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Feature Flag Management") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color(0xFF4CAF50)) // A green color
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = {
+                newFlagName = ""; newFlagDesc = ""; newFlagSegment = "" // Clear fields before showing
+                showCreateDialog = true
+            }) {
+                Icon(Icons.Filled.Add, "Create new flag")
+            }
+        }
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = Modifier.padding(paddingValues).padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            items(flags, key = { it.name }) { flag -> // Added key for better performance
+                FeatureFlagCard(
+                    flag = flag,
+                    onEditClick = {
+                        currentEditingFlag = it
+                        showEditDialog = true
+                    },
+                    onDeleteClick = { viewModel.deleteFlag(it.name) },
+                    onToggleStatus = { viewModel.updateFlagStatus(flag.name, !flag.isActive) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun FeatureFlagCard(
+    flag: FeatureFlag,
+    onEditClick: (FeatureFlag) -> Unit,
+    onDeleteClick: (FeatureFlag) -> Unit,
+    onToggleStatus: () -> Unit
+) {
+    Card(elevation = CardDefaults.cardElevation(defaultElevation = 2.dp), modifier = Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(flag.name, style = MaterialTheme.typography.titleLarge)
+            Text("Description: ${flag.description}", style = MaterialTheme.typography.bodyMedium)
+            Text("Target Segment: ${flag.targetUserSegment}", style = MaterialTheme.typography.bodySmall)
+            Text("Rollout: ${flag.rolloutPercentage}%", style = MaterialTheme.typography.bodySmall)
+            Text("Created By: ${flag.createdBy} at ${flag.formattedCreatedAt}", style = MaterialTheme.typography.bodySmall)
+            Text("Last Updated: ${flag.formattedUpdatedAt}", style = MaterialTheme.typography.bodySmall)
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(top = 8.dp).fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                     Text("Active: ", style = MaterialTheme.typography.labelMedium)
+                     Switch(checked = flag.isActive, onCheckedChange = { onToggleStatus() })
+                }
+                Row {
+                    IconButton(onClick = { onEditClick(flag) }) {
+                        Icon(Icons.Filled.Edit, "Edit Flag")
+                    }
+                    IconButton(onClick = { onDeleteClick(flag) }) {
+                        Icon(Icons.Filled.Delete, "Delete Flag", tint = MaterialTheme.colorScheme.error)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun EditFeatureFlagDialog(
+    flag: FeatureFlag,
+    viewModel: FeatureFlagViewModel,
+    onDismiss: () -> Unit
+) {
+    var description by remember { mutableStateOf(flag.description) }
+    var rolloutPercentage by remember { mutableStateOf(flag.rolloutPercentage.toString()) }
+    var targetSegment by remember { mutableStateOf(flag.targetUserSegment) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Edit: ${flag.name}") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(value = description, onValueChange = { description = it }, label = { Text("Description") })
+                OutlinedTextField(
+                    value = rolloutPercentage,
+                    onValueChange = { newValue ->
+                        val filtered = newValue.filter { char -> char.isDigit() }
+                        if (filtered.isEmpty() || (filtered.toIntOrNull() ?: 0) <= 100) {
+                             rolloutPercentage = filtered
+                        } else if (filtered.toInt() > 100) {
+                            rolloutPercentage = "100"
+                        }
+                    },
+                    label = { Text("Rollout % (0-100)") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    singleLine = true
+                )
+                OutlinedTextField(value = targetSegment, onValueChange = { targetSegment = it }, label = { Text("Target Segment") }, singleLine = true)
+            }
+        },
+        confirmButton = {
+            Button(onClick = {
+                viewModel.updateDescription(flag.name, description.trim())
+                val percentValue = rolloutPercentage.toIntOrNull() ?: flag.rolloutPercentage
+                viewModel.updateRolloutPercentage(flag.name, if(percentValue in 0..100) percentValue else flag.rolloutPercentage)
+                viewModel.updateTargetSegment(flag.name, targetSegment.trim())
+                onDismiss()
+            }) { Text("Save Changes") }
+        },
+        dismissButton = { Button(onClick = onDismiss) { Text("Cancel") } }
+    )
+}
+
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewFeatureFlagScreen() {
+    MaterialTheme {
+        FeatureFlagScreen(viewModel = FeatureFlagViewModel())
+    }
+}

--- a/app/src/main/java/com/example/rooster/admin/systemmonitoring/SystemMonitoringScreen.kt
+++ b/app/src/main/java/com/example/rooster/admin/systemmonitoring/SystemMonitoringScreen.kt
@@ -1,0 +1,374 @@
+package com.example.rooster.admin.systemmonitoring
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+// --- Data classes to mirror Python structure ---
+data class ServerHealthData(
+    val name: String,
+    val status: String,
+    val cpuUsage: String,
+    val memoryUsage: String
+)
+
+data class ApiPerformanceData(
+    val endpoint: String,
+    val avgResponseTime: String,
+    val errorRate: String,
+    val requestsPerMinute: Int
+)
+
+data class ErrorLogData(
+    val timestamp: Date,
+    val errorCode: Int,
+    val message: String,
+    val source: String
+) {
+    fun getFormattedTimestamp(): String {
+        val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
+        return sdf.format(timestamp)
+    }
+}
+
+// --- ViewModel to hold and manage UI state ---
+// In a real app, HiltViewModel would be used for DI
+class SystemMonitoringViewModel : ViewModel() {
+    // Mock data similar to Python script
+    private val _serverHealth = MutableStateFlow<List<ServerHealthData>>(emptyList())
+    val serverHealth: StateFlow<List<ServerHealthData>> = _serverHealth
+
+    private val _apiPerformance = MutableStateFlow<List<ApiPerformanceData>>(emptyList())
+    val apiPerformance: StateFlow<List<ApiPerformanceData>> = _apiPerformance
+
+    private val _errorTracking = MutableStateFlow<List<ErrorLogData>>(emptyList())
+    val errorTracking: StateFlow<List<ErrorLogData>> = _errorTracking
+
+    init {
+        loadMockData()
+    }
+
+    private fun loadMockData() {
+        _serverHealth.value = listOf(
+            ServerHealthData("server1", "online", "15%", "45GB/64GB"),
+            ServerHealthData("server2", "online", "25%", "50GB/64GB"),
+            ServerHealthData("server3", "offline", "N/A", "N/A")
+        )
+
+        _apiPerformance.value = listOf(
+            ApiPerformanceData("/api/users", "120ms", "0.5%", 1200),
+            ApiPerformanceData("/api/pets", "150ms", "1.2%", 800),
+            ApiPerformanceData("/api/consultations", "200ms", "0.2%", 500)
+        )
+
+        _errorTracking.value = listOf(
+            ErrorLogData(Date(System.currentTimeMillis() - 5 * 60000), 500, "Internal Server Error on /api/payments", "server2"),
+            ErrorLogData(Date(System.currentTimeMillis() - 15 * 60000), 404, "Resource not found on /api/users/unknown", "server1"),
+            ErrorLogData(Date(System.currentTimeMillis() - 30 * 60000), 403, "Forbidden access to /api/admin/config", "server1")
+        )
+    }
+}
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SystemMonitoringScreen(viewModel: SystemMonitoringViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val serverHealthData by viewModel.serverHealth.collectAsState()
+    val apiPerformanceData by viewModel.apiPerformance.collectAsState()
+    val errorTrackingData by viewModel.errorTracking.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("System Monitoring") },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = Color.LightGray // Example color
+                )
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(modifier = Modifier.padding(paddingValues).padding(16.dp)) {
+            item {
+                Text("Server Health", style = androidx.compose.material3.MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(bottom = 8.dp))
+            }
+            items(serverHealthData) { server ->
+                ServerHealthCard(server)
+            }
+
+            item {
+                Text("API Performance", style = androidx.compose.material3.MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(top = 16.dp, bottom = 8.dp))
+            }
+            items(apiPerformanceData) { api ->
+                ApiPerformanceCard(api)
+            }
+
+            item {
+                Text("Error Tracking", style = androidx.compose.material3.MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(top = 16.dp, bottom = 8.dp))
+            }
+            items(errorTrackingData) { errorLog ->
+                ErrorLogCard(errorLog)
+            }
+        }
+    }
+}
+
+@Composable
+fun ServerHealthCard(data: ServerHealthData) {
+    Card(
+        modifier = Modifier.padding(vertical = 4.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Server: ${data.name}", style = androidx.compose.material3.MaterialTheme.typography.titleMedium)
+            Text("Status: ${data.status}", color = if (data.status == "online") Color.Green else Color.Red)
+            Text("CPU Usage: ${data.cpuUsage}")
+            Text("Memory: ${data.memoryUsage}")
+        }
+    }
+}
+
+@Composable
+fun ApiPerformanceCard(data: ApiPerformanceData) {
+    Card(
+        modifier = Modifier.padding(vertical = 4.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Endpoint: ${data.endpoint}", style = androidx.compose.material3.MaterialTheme.typography.titleMedium)
+            Text("Avg Response: ${data.avgResponseTime}")
+            Text("Error Rate: ${data.errorRate}")
+            Text("RPM: ${data.requestsPerMinute}")
+        }
+    }
+}
+
+@Composable
+fun ErrorLogCard(data: ErrorLogData) {
+    Card(
+        modifier = Modifier.padding(vertical = 4.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Error: ${data.errorCode} - ${data.message}", style = androidx.compose.material3.MaterialTheme.typography.titleMedium)
+            Text("Source: ${data.source}")
+            Text("Timestamp: ${data.getFormattedTimestamp()}")
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewSystemMonitoringScreen() {
+    // You might need to provide a mock ViewModel or use hardcoded data for previews
+    // if the default viewModel() call doesn't work well in previews without Hilt setup.
+    // For simplicity, we'll assume the default viewModel() works or use a simple instance.
+    SystemMonitoringScreen(viewModel = SystemMonitoringViewModel())
+}
+package com.example.rooster.admin.systemmonitoring
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+// --- Data classes to mirror Python structure ---
+data class ServerHealthData(
+    val name: String,
+    val status: String,
+    val cpuUsage: String,
+    val memoryUsage: String
+)
+
+data class ApiPerformanceData(
+    val endpoint: String,
+    val avgResponseTime: String,
+    val errorRate: String,
+    val requestsPerMinute: Int
+)
+
+data class ErrorLogData(
+    val timestamp: Date,
+    val errorCode: Int,
+    val message: String,
+    val source: String
+) {
+    fun getFormattedTimestamp(): String {
+        val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
+        return sdf.format(timestamp)
+    }
+}
+
+// --- ViewModel to hold and manage UI state ---
+// In a real app, HiltViewModel would be used for DI
+class SystemMonitoringViewModel : ViewModel() {
+    // Mock data similar to Python script
+    private val _serverHealth = MutableStateFlow<List<ServerHealthData>>(emptyList())
+    val serverHealth: StateFlow<List<ServerHealthData>> = _serverHealth
+
+    private val _apiPerformance = MutableStateFlow<List<ApiPerformanceData>>(emptyList())
+    val apiPerformance: StateFlow<List<ApiPerformanceData>> = _apiPerformance
+
+    private val _errorTracking = MutableStateFlow<List<ErrorLogData>>(emptyList())
+    val errorTracking: StateFlow<List<ErrorLogData>> = _errorTracking
+
+    init {
+        loadMockData()
+    }
+
+    private fun loadMockData() {
+        _serverHealth.value = listOf(
+            ServerHealthData("server1", "online", "15%", "45GB/64GB"),
+            ServerHealthData("server2", "online", "25%", "50GB/64GB"),
+            ServerHealthData("server3", "offline", "N/A", "N/A")
+        )
+
+        _apiPerformance.value = listOf(
+            ApiPerformanceData("/api/users", "120ms", "0.5%", 1200),
+            ApiPerformanceData("/api/pets", "150ms", "1.2%", 800),
+            ApiPerformanceData("/api/consultations", "200ms", "0.2%", 500)
+        )
+
+        _errorTracking.value = listOf(
+            ErrorLogData(Date(System.currentTimeMillis() - 5 * 60000), 500, "Internal Server Error on /api/payments", "server2"),
+            ErrorLogData(Date(System.currentTimeMillis() - 15 * 60000), 404, "Resource not found on /api/users/unknown", "server1"),
+            ErrorLogData(Date(System.currentTimeMillis() - 30 * 60000), 403, "Forbidden access to /api/admin/config", "server1")
+        )
+    }
+}
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SystemMonitoringScreen(viewModel: SystemMonitoringViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val serverHealthData by viewModel.serverHealth.collectAsState()
+    val apiPerformanceData by viewModel.apiPerformance.collectAsState()
+    val errorTrackingData by viewModel.errorTracking.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("System Monitoring") },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = Color.LightGray // Example color
+                )
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(modifier = Modifier.padding(paddingValues).padding(16.dp)) {
+            item {
+                Text("Server Health", style = androidx.compose.material3.MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(bottom = 8.dp))
+            }
+            items(serverHealthData) { server ->
+                ServerHealthCard(server)
+            }
+
+            item {
+                Text("API Performance", style = androidx.compose.material3.MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(top = 16.dp, bottom = 8.dp))
+            }
+            items(apiPerformanceData) { api ->
+                ApiPerformanceCard(api)
+            }
+
+            item {
+                Text("Error Tracking", style = androidx.compose.material3.MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(top = 16.dp, bottom = 8.dp))
+            }
+            items(errorTrackingData) { errorLog ->
+                ErrorLogCard(errorLog)
+            }
+        }
+    }
+}
+
+@Composable
+fun ServerHealthCard(data: ServerHealthData) {
+    Card(
+        modifier = Modifier.padding(vertical = 4.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Server: ${data.name}", style = androidx.compose.material3.MaterialTheme.typography.titleMedium)
+            Text("Status: ${data.status}", color = if (data.status == "online") Color.Green else Color.Red)
+            Text("CPU Usage: ${data.cpuUsage}")
+            Text("Memory: ${data.memoryUsage}")
+        }
+    }
+}
+
+@Composable
+fun ApiPerformanceCard(data: ApiPerformanceData) {
+    Card(
+        modifier = Modifier.padding(vertical = 4.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Endpoint: ${data.endpoint}", style = androidx.compose.material3.MaterialTheme.typography.titleMedium)
+            Text("Avg Response: ${data.avgResponseTime}")
+            Text("Error Rate: ${data.errorRate}")
+            Text("RPM: ${data.requestsPerMinute}")
+        }
+    }
+}
+
+@Composable
+fun ErrorLogCard(data: ErrorLogData) {
+    Card(
+        modifier = Modifier.padding(vertical = 4.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Error: ${data.errorCode} - ${data.message}", style = androidx.compose.material3.MaterialTheme.typography.titleMedium)
+            Text("Source: ${data.source}")
+            Text("Timestamp: ${data.getFormattedTimestamp()}")
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewSystemMonitoringScreen() {
+    // You might need to provide a mock ViewModel or use hardcoded data for previews
+    // if the default viewModel() call doesn't work well in previews without Hilt setup.
+    // For simplicity, we'll assume the default viewModel() works or use a simple instance.
+    SystemMonitoringScreen(viewModel = SystemMonitoringViewModel())
+}

--- a/app/src/main/java/com/example/rooster/admin/usermanagement/UserManagementScreen.kt
+++ b/app/src/main/java/com/example/rooster/admin/usermanagement/UserManagementScreen.kt
@@ -1,0 +1,502 @@
+package com.example.rooster.admin.usermanagement
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AddCircle
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Face
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+// --- Data Classes ---
+data class UserProfile(
+    val name: String,
+    val details: Map<String, String> // e.g., specialty, farm_size
+)
+
+data class UserData(
+    val id: String,
+    val email: String,
+    var isVerified: Boolean,
+    var roles: List<String>,
+    var accountStatus: String,
+    val lastLogin: Date?,
+    val profile: UserProfile?
+) {
+    fun getFormattedLastLogin(): String {
+        return lastLogin?.let {
+            SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(it)
+        } ?: "Never"
+    }
+}
+
+// --- ViewModel ---
+class UserManagementViewModel : ViewModel() {
+    private val _users = MutableStateFlow<List<UserData>>(emptyList())
+    val users: StateFlow<List<UserData>> = _users
+
+    init {
+        loadMockUsers()
+    }
+
+    private fun loadMockUsers() {
+        _users.value = listOf(
+            UserData(
+                "user001", "alice@example.com", true, listOf("veterinarian", "admin"), "active",
+                Date(System.currentTimeMillis() - 2 * 3600000),
+                UserProfile("Dr. Alice Smith", mapOf("specialty" to "General Practice"))
+            ),
+            UserData(
+                "user002", "bob@example.com", false, listOf("farmer"), "pending_verification",
+                null,
+                UserProfile("Bob Johnson", mapOf("farm_size" to "100 acres"))
+            ),
+            UserData(
+                "user003", "charlie@example.com", true, listOf("farmer", "seller"), "active",
+                Date(System.currentTimeMillis() - 24 * 3600000),
+                UserProfile("Charlie Brown", mapOf("store_name" to "Brown's Farm Produce"))
+            ),
+            UserData(
+                "user004", "diana@example.com", true, listOf("veterinarian"), "suspended",
+                Date(System.currentTimeMillis() - 7 * 24 * 3600000),
+                UserProfile("Dr. Diana Prince", mapOf("specialty" to "Surgery"))
+            )
+        )
+    }
+
+    fun verifyUser(userId: String) {
+        _users.update { currentUsers ->
+            currentUsers.map { user ->
+                if (user.id == userId) {
+                    user.copy(isVerified = true, accountStatus = "active")
+                } else user
+            }
+        }
+    }
+
+    fun assignRole(userId: String, role: String) {
+        _users.update { currentUsers ->
+            currentUsers.map { user ->
+                if (user.id == userId && !user.roles.contains(role)) {
+                    user.copy(roles = user.roles + role)
+                } else user
+            }
+        }
+    }
+
+    fun revokeRole(userId: String, role: String) {
+        _users.update { currentUsers ->
+            currentUsers.map { user ->
+                if (user.id == userId && user.roles.contains(role)) {
+                    user.copy(roles = user.roles - role)
+                } else user
+            }
+        }
+    }
+
+    fun changeAccountStatus(userId: String, newStatus: String) {
+        _users.update { currentUsers ->
+            currentUsers.map { user ->
+                if (user.id == userId) {
+                    user.copy(accountStatus = newStatus)
+                } else user
+            }
+        }
+    }
+}
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun UserManagementScreen(viewModel: UserManagementViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val users by viewModel.users.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("User Management") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Cyan) // Example color
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = Modifier
+                .padding(paddingValues)
+                .padding(16.dp)
+        ) {
+            items(users) { user ->
+                UserCard(user, viewModel)
+            }
+        }
+    }
+}
+
+@Composable
+fun UserCard(user: UserData, viewModel: UserManagementViewModel) {
+    var showDialog by remember { mutableStateOf(false) }
+    var actionType by remember { mutableStateOf("") } // "assignRole", "revokeRole", "changeStatus"
+    var inputValue by remember { mutableStateOf("") }
+
+
+    if (showDialog) {
+        AlertDialog(
+            onDismissRequest = { showDialog = false },
+            title = { Text("Perform Action on ${user.email}") },
+            text = {
+                Column {
+                    Text("Current Status: ${user.accountStatus}")
+                    Text("Current Roles: ${user.roles.joinToString()}")
+                    if (actionType == "assignRole" || actionType == "revokeRole") {
+                        OutlinedTextField(
+                            value = inputValue,
+                            onValueChange = { inputValue = it },
+                            label = { Text("Role Name") }
+                        )
+                    } else if (actionType == "changeStatus") {
+                         OutlinedTextField(
+                            value = inputValue,
+                            onValueChange = { inputValue = it },
+                            label = { Text("New Status (e.g., active, suspended)") }
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                Button(onClick = {
+                    when (actionType) {
+                        "assignRole" -> viewModel.assignRole(user.id, inputValue)
+                        "revokeRole" -> viewModel.revokeRole(user.id, inputValue)
+                        "changeStatus" -> viewModel.changeAccountStatus(user.id, inputValue)
+                    }
+                    showDialog = false
+                    inputValue = ""
+                }) { Text("Confirm") }
+            },
+            dismissButton = {
+                Button(onClick = { showDialog = false }) { Text("Cancel") }
+            }
+        )
+    }
+
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("ID: ${user.id}", style = MaterialTheme.typography.titleMedium)
+            Text("Email: ${user.email}")
+            Text("Verified: ${if (user.isVerified) "Yes" else "No"}", color = if (user.isVerified) Color.Green else Color.Red)
+            Text("Roles: ${user.roles.joinToString(", ")}")
+            Text("Status: ${user.accountStatus}", color = when(user.accountStatus){
+                "active" -> Color.Green
+                "pending_verification" -> Color.Blue
+                "suspended" -> Color.Magenta
+                else -> Color.Gray
+            })
+            Text("Last Login: ${user.getFormattedLastLogin()}")
+            user.profile?.let { profile ->
+                Text("Profile Name: ${profile.name}")
+                profile.details.forEach { (key, value) ->
+                    Text("${key.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }}: $value")
+                }
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceAround
+            ) {
+                if (!user.isVerified) {
+                    Button(onClick = { viewModel.verifyUser(user.id) }) {
+                        Text("Verify")
+                    }
+                }
+                IconButton(onClick = { actionType = "assignRole"; inputValue = ""; showDialog = true }) {
+                    Icon(Icons.Default.AddCircle, contentDescription = "Assign Role")
+                }
+                IconButton(onClick = { actionType = "revokeRole"; inputValue = ""; showDialog = true }) {
+                    Icon(Icons.Default.Delete, contentDescription = "Revoke Role")
+                }
+                 IconButton(onClick = { actionType = "changeStatus"; inputValue = user.accountStatus; showDialog = true }) {
+                    Icon(Icons.Default.Edit, contentDescription = "Change Status")
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewUserManagementScreen() {
+    MaterialTheme { // Wrap in MaterialTheme for preview
+        UserManagementScreen(viewModel = UserManagementViewModel())
+    }
+}
+package com.example.rooster.admin.usermanagement
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AddCircle
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Face
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+// --- Data Classes ---
+data class UserProfile(
+    val name: String,
+    val details: Map<String, String> // e.g., specialty, farm_size
+)
+
+data class UserData(
+    val id: String,
+    val email: String,
+    var isVerified: Boolean,
+    var roles: List<String>,
+    var accountStatus: String,
+    val lastLogin: Date?,
+    val profile: UserProfile?
+) {
+    fun getFormattedLastLogin(): String {
+        return lastLogin?.let {
+            SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(it)
+        } ?: "Never"
+    }
+}
+
+// --- ViewModel ---
+class UserManagementViewModel : ViewModel() {
+    private val _users = MutableStateFlow<List<UserData>>(emptyList())
+    val users: StateFlow<List<UserData>> = _users
+
+    init {
+        loadMockUsers()
+    }
+
+    private fun loadMockUsers() {
+        _users.value = listOf(
+            UserData(
+                "user001", "alice@example.com", true, listOf("veterinarian", "admin"), "active",
+                Date(System.currentTimeMillis() - 2 * 3600000),
+                UserProfile("Dr. Alice Smith", mapOf("specialty" to "General Practice"))
+            ),
+            UserData(
+                "user002", "bob@example.com", false, listOf("farmer"), "pending_verification",
+                null,
+                UserProfile("Bob Johnson", mapOf("farm_size" to "100 acres"))
+            ),
+            UserData(
+                "user003", "charlie@example.com", true, listOf("farmer", "seller"), "active",
+                Date(System.currentTimeMillis() - 24 * 3600000),
+                UserProfile("Charlie Brown", mapOf("store_name" to "Brown's Farm Produce"))
+            ),
+            UserData(
+                "user004", "diana@example.com", true, listOf("veterinarian"), "suspended",
+                Date(System.currentTimeMillis() - 7 * 24 * 3600000),
+                UserProfile("Dr. Diana Prince", mapOf("specialty" to "Surgery"))
+            )
+        )
+    }
+
+    fun verifyUser(userId: String) {
+        _users.update { currentUsers ->
+            currentUsers.map { user ->
+                if (user.id == userId) {
+                    user.copy(isVerified = true, accountStatus = "active")
+                } else user
+            }
+        }
+    }
+
+    fun assignRole(userId: String, role: String) {
+        _users.update { currentUsers ->
+            currentUsers.map { user ->
+                if (user.id == userId && !user.roles.contains(role)) {
+                    user.copy(roles = user.roles + role)
+                } else user
+            }
+        }
+    }
+
+    fun revokeRole(userId: String, role: String) {
+        _users.update { currentUsers ->
+            currentUsers.map { user ->
+                if (user.id == userId && user.roles.contains(role)) {
+                    user.copy(roles = user.roles - role)
+                } else user
+            }
+        }
+    }
+
+    fun changeAccountStatus(userId: String, newStatus: String) {
+        _users.update { currentUsers ->
+            currentUsers.map { user ->
+                if (user.id == userId) {
+                    user.copy(accountStatus = newStatus)
+                } else user
+            }
+        }
+    }
+}
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun UserManagementScreen(viewModel: UserManagementViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val users by viewModel.users.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("User Management") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Cyan) // Example color
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = Modifier
+                .padding(paddingValues)
+                .padding(16.dp)
+        ) {
+            items(users) { user ->
+                UserCard(user, viewModel)
+            }
+        }
+    }
+}
+
+@Composable
+fun UserCard(user: UserData, viewModel: UserManagementViewModel) {
+    var showDialog by remember { mutableStateOf(false) }
+    var actionType by remember { mutableStateOf("") } // "assignRole", "revokeRole", "changeStatus"
+    var inputValue by remember { mutableStateOf("") }
+
+
+    if (showDialog) {
+        AlertDialog(
+            onDismissRequest = { showDialog = false },
+            title = { Text("Perform Action on ${user.email}") },
+            text = {
+                Column {
+                    Text("Current Status: ${user.accountStatus}")
+                    Text("Current Roles: ${user.roles.joinToString()}")
+                    if (actionType == "assignRole" || actionType == "revokeRole") {
+                        OutlinedTextField(
+                            value = inputValue,
+                            onValueChange = { inputValue = it },
+                            label = { Text("Role Name") }
+                        )
+                    } else if (actionType == "changeStatus") {
+                         OutlinedTextField(
+                            value = inputValue,
+                            onValueChange = { inputValue = it },
+                            label = { Text("New Status (e.g., active, suspended)") }
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                Button(onClick = {
+                    when (actionType) {
+                        "assignRole" -> viewModel.assignRole(user.id, inputValue)
+                        "revokeRole" -> viewModel.revokeRole(user.id, inputValue)
+                        "changeStatus" -> viewModel.changeAccountStatus(user.id, inputValue)
+                    }
+                    showDialog = false
+                    inputValue = ""
+                }) { Text("Confirm") }
+            },
+            dismissButton = {
+                Button(onClick = { showDialog = false }) { Text("Cancel") }
+            }
+        )
+    }
+
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("ID: ${user.id}", style = MaterialTheme.typography.titleMedium)
+            Text("Email: ${user.email}")
+            Text("Verified: ${if (user.isVerified) "Yes" else "No"}", color = if (user.isVerified) Color.Green else Color.Red)
+            Text("Roles: ${user.roles.joinToString(", ")}")
+            Text("Status: ${user.accountStatus}", color = when(user.accountStatus){
+                "active" -> Color.Green
+                "pending_verification" -> Color.Blue
+                "suspended" -> Color.Magenta
+                else -> Color.Gray
+            })
+            Text("Last Login: ${user.getFormattedLastLogin()}")
+            user.profile?.let { profile ->
+                Text("Profile Name: ${profile.name}")
+                profile.details.forEach { (key, value) ->
+                    Text("${key.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }}: $value")
+                }
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceAround
+            ) {
+                if (!user.isVerified) {
+                    Button(onClick = { viewModel.verifyUser(user.id) }) {
+                        Text("Verify")
+                    }
+                }
+                IconButton(onClick = { actionType = "assignRole"; inputValue = ""; showDialog = true }) {
+                    Icon(Icons.Default.AddCircle, contentDescription = "Assign Role")
+                }
+                IconButton(onClick = { actionType = "revokeRole"; inputValue = ""; showDialog = true }) {
+                    Icon(Icons.Default.Delete, contentDescription = "Revoke Role")
+                }
+                 IconButton(onClick = { actionType = "changeStatus"; inputValue = user.accountStatus; showDialog = true }) {
+                    Icon(Icons.Default.Edit, contentDescription = "Change Status")
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewUserManagementScreen() {
+    MaterialTheme { // Wrap in MaterialTheme for preview
+        UserManagementScreen(viewModel = UserManagementViewModel())
+    }
+}

--- a/app/src/main/java/com/example/rooster/financials/FinancialsDashboardScreen.kt
+++ b/app/src/main/java/com/example/rooster/financials/FinancialsDashboardScreen.kt
@@ -1,0 +1,88 @@
+package com.example.rooster.financials
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.example.rooster.financials.commission.CommissionManagementScreen
+import com.example.rooster.financials.reports.FinancialReportsScreen
+import com.example.rooster.financials.payouts.PayoutSystemScreen
+import com.example.rooster.financials.revenueanalytics.RevenueAnalyticsScreen
+import com.example.rooster.financials.transactions.TransactionMonitoringScreen
+
+object FinancialsDestinations {
+    const val DASHBOARD = "financials_dashboard"
+    const val COMMISSION_MANAGEMENT = "financials_commission_management"
+    const val FINANCIAL_REPORTS = "financials_reports"
+    const val PAYOUT_SYSTEM = "financials_payout_system"
+    const val REVENUE_ANALYTICS = "financials_revenue_analytics"
+    const val TRANSACTION_MONITORING = "financials_transaction_monitoring"
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FinancialsDashboardScreen(navController: NavController) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Financials Dashboard") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color(0xFF26A69A)) // Teal
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxSize()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            item { FinancialsDashboardButton(navController, "Commission Management", FinancialsDestinations.COMMISSION_MANAGEMENT) }
+            item { FinancialsDashboardButton(navController, "Financial Reports", FinancialsDestinations.FINANCIAL_REPORTS) }
+            item { FinancialsDashboardButton(navController, "Payout System", FinancialsDestinations.PAYOUT_SYSTEM) }
+            item { FinancialsDashboardButton(navController, "Revenue Analytics", FinancialsDestinations.REVENUE_ANALYTICS) }
+            item { FinancialsDashboardButton(navController, "Transaction Monitoring", FinancialsDestinations.TRANSACTION_MONITORING) }
+        }
+    }
+}
+
+@Composable
+fun FinancialsDashboardButton(navController: NavController, text: String, route: String) {
+    Button(
+        onClick = { navController.navigate(route) },
+        modifier = Modifier.fillMaxWidth(0.8f).height(50.dp)
+    ) {
+        Text(text)
+    }
+}
+
+@Composable
+fun FinancialsFeatureNavigator() {
+    val navController = rememberNavController()
+    NavHost(navController = navController, startDestination = FinancialsDestinations.DASHBOARD) {
+        composable(FinancialsDestinations.DASHBOARD) { FinancialsDashboardScreen(navController) }
+        composable(FinancialsDestinations.COMMISSION_MANAGEMENT) { CommissionManagementScreen() }
+        composable(FinancialsDestinations.FINANCIAL_REPORTS) { FinancialReportsScreen() }
+        composable(FinancialsDestinations.PAYOUT_SYSTEM) { PayoutSystemScreen() }
+        composable(FinancialsDestinations.REVENUE_ANALYTICS) { RevenueAnalyticsScreen() }
+        composable(FinancialsDestinations.TRANSACTION_MONITORING) { TransactionMonitoringScreen() }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewFinancialsDashboardScreen() {
+    MaterialTheme {
+        FinancialsFeatureNavigator()
+    }
+}

--- a/app/src/main/java/com/example/rooster/financials/commission/CommissionManagementScreen.kt
+++ b/app/src/main/java/com/example/rooster/financials/commission/CommissionManagementScreen.kt
@@ -1,0 +1,303 @@
+package com.example.rooster.financials.commission
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import java.text.DecimalFormat
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+// --- Data Classes ---
+data class CommissionRate(
+    val key: String, // e.g., "default", "electronics_category"
+    var rate: Double, // e.g., 0.05 for 5%
+    var description: String,
+    var updatedAt: Date? = null,
+    var updatedBy: String? = null
+) {
+    val displayRate: String get() = "${(rate * 100).format(2)}%"
+    fun formattedUpdatedAt(): String? = updatedAt?.let {
+        SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(it)
+    }
+}
+
+data class CommissionedTransaction(
+    val transactionId: String,
+    val sellerId: String,
+    val saleAmount: Double,
+    val category: String,
+    val transactionDate: Date,
+    val commissionRateKey: String,
+    val commissionRateApplied: Double,
+    val commissionAmount: Double,
+    val payoutStatus: String // "pending", "paid_out"
+) {
+    fun formattedTransactionDate(): String =
+        SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(transactionDate)
+    val displayCommissionRateApplied: String get() = "${(commissionRateApplied * 100).format(1)}%"
+}
+
+// Extension to format double to specific decimal places
+fun Double.format(digits: Int) = "%.${digits}f".format(this)
+
+
+// --- ViewModel ---
+class CommissionManagementViewModel : ViewModel() {
+    private val _commissionRates = MutableStateFlow<List<CommissionRate>>(emptyList())
+    val commissionRates: StateFlow<List<CommissionRate>> = _commissionRates
+
+    private val _commissionedTransactions = MutableStateFlow<List<CommissionedTransaction>>(emptyList())
+    val commissionedTransactions: StateFlow<List<CommissionedTransaction>> = _commissionedTransactions
+
+    // For displaying pending payouts for a specific seller (example)
+    private val _pendingSellerPayouts = MutableStateFlow<List<CommissionedTransaction>>(emptyList())
+    val pendingSellerPayouts: StateFlow<List<CommissionedTransaction>> = _pendingSellerPayouts
+    var displayedSellerIdForPayouts by mutableStateOf("seller002") // Default or can be changed
+
+    init {
+        loadMockData()
+        filterPendingPayoutsForSeller(displayedSellerIdForPayouts)
+    }
+
+    private fun loadMockData() {
+        val now = Date()
+        _commissionRates.value = listOf(
+            CommissionRate("default", 0.05, "Standard commission rate", now, "system"),
+            CommissionRate("electronics_category", 0.08, "Commission for electronics", now, "system"),
+            CommissionRate("veterinary_services", 0.10, "Commission for vet services", Date(now.time - 86400000L), "admin_jane"),
+            CommissionRate("premium_seller_tier", 0.03, "Reduced commission for premium sellers", Date(now.time - 2*86400000L), "admin_john")
+        ).sortedBy { it.key }
+
+        val transactions = mutableListOf<CommissionedTransaction>()
+        val sellerIds = (1..5).map { "seller${it.toString().padStart(3, '0')}" }
+        val categories = listOf("general", "electronics_category", "veterinary_services", "books")
+        for (i in 0..19) {
+            val category = categories.random()
+            val rateDetails = _commissionRates.value.find { it.key == category } ?: _commissionRates.value.first { it.key == "default" }
+            val saleAmount = (20..300).random().toDouble()
+            transactions.add(
+                CommissionedTransaction(
+                    transactionId = "sale_txn_${now.time - (0..30).random() * 86400000L}_${i.toString().padStart(3, '0')}",
+                    sellerId = sellerIds.random(),
+                    saleAmount = saleAmount,
+                    category = category,
+                    transactionDate = Date(now.time - (0..30).random() * 86400000L),
+                    commissionRateKey = rateDetails.key,
+                    commissionRateApplied = rateDetails.rate,
+                    commissionAmount = saleAmount * rateDetails.rate,
+                    payoutStatus = if (Math.random() > 0.5) "pending" else "paid_out"
+                )
+            )
+        }
+        _commissionedTransactions.value = transactions.sortedByDescending { it.transactionDate }
+    }
+
+    fun setCommissionRate(key: String, newRate: Double, newDescription: String, adminId: String) {
+        if (newRate < 0 || newRate > 1) {
+            println("Error: Rate must be between 0 and 1.")
+            return
+        }
+        _commissionRates.update { currentRates ->
+            val existingRate = currentRates.find { it.key == key }
+            if (existingRate != null) {
+                currentRates.map {
+                    if (it.key == key) it.copy(rate = newRate, description = newDescription, updatedAt = Date(), updatedBy = adminId)
+                    else it
+                }
+            } else {
+                currentRates + CommissionRate(key, newRate, newDescription, Date(), adminId)
+            }.sortedBy { it.key }
+        }
+    }
+
+    fun filterPendingPayoutsForSeller(sellerId: String) {
+        displayedSellerIdForPayouts = sellerId
+        _pendingSellerPayouts.value = _commissionedTransactions.value.filter {
+            it.sellerId == sellerId && it.payoutStatus == "pending"
+        }
+    }
+}
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CommissionManagementScreen(viewModel: CommissionManagementViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val rates by viewModel.commissionRates.collectAsState()
+    val transactions by viewModel.commissionedTransactions.collectAsState()
+    val pendingPayouts by viewModel.pendingSellerPayouts.collectAsState()
+    val displayedSellerId by remember { derivedStateOf { viewModel.displayedSellerIdForPayouts } }
+
+
+    var showEditRateDialog by remember { mutableStateOf(false) }
+    var editingRate by remember { mutableStateOf<CommissionRate?>(null) }
+
+    if (showEditRateDialog && editingRate != null) {
+        EditCommissionRateDialog(
+            rate = editingRate!!,
+            onDismiss = { showEditRateDialog = false; editingRate = null },
+            onSave = { key, newRate, newDesc ->
+                viewModel.setCommissionRate(key, newRate, newDesc, "admin_compose")
+                showEditRateDialog = false
+                editingRate = null
+            }
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Commission Management") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color(0xFFFFA726)) // Orange
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = {
+                // For simplicity, editing an existing or adding a new one could use same dialog.
+                // Here, let's make it trigger an add for "new_category_rate"
+                editingRate = CommissionRate("new_category_rate", 0.12, "New custom rate", null, null)
+                showEditRateDialog = true
+            }) {
+                Icon(Icons.Filled.Add, "Add new commission rate")
+            }
+        }
+    ) { paddingValues ->
+        LazyColumn(modifier = Modifier.padding(paddingValues).padding(16.dp)) {
+            item {
+                Text("Current Commission Rates", style = MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(bottom = 8.dp))
+            }
+            items(rates, key = {it.key}) { rate ->
+                CommissionRateCard(rate) {
+                    editingRate = it
+                    showEditRateDialog = true
+                }
+            }
+
+            item {
+                Text("Recent Commissioned Transactions (Top 5)", style = MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(top = 16.dp, bottom = 8.dp))
+            }
+            items(transactions.take(5)) { tx ->
+                CommissionedTransactionCard(tx)
+            }
+
+            item {
+                Column(modifier = Modifier.padding(top = 16.dp)) {
+                    Text("Pending Payouts for Seller: $displayedSellerId", style = MaterialTheme.typography.headlineSmall)
+                     // Basic filter input - in real app more robust
+                    var sellerInputId by remember { mutableStateOf(displayedSellerId) }
+                    OutlinedTextField(
+                        value = sellerInputId,
+                        onValueChange = { sellerInputId = it },
+                        label = { Text("Enter Seller ID to Filter")},
+                        modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+                        trailingIcon = { Button(onClick = { viewModel.filterPendingPayoutsForSeller(sellerInputId.trim())}) { Text("Filter") } }
+                    )
+                }
+            }
+            if(pendingPayouts.isEmpty()){
+                item { Text("No pending payouts for $displayedSellerId") }
+            } else {
+                items(pendingPayouts) {tx ->
+                     CommissionedTransactionCard(tx, isPayoutView = true)
+                }
+                item {
+                    val totalPending = pendingPayouts.sumOf { it.commissionAmount }
+                    Text("Total Pending for $displayedSellerId: $${totalPending.format(2)}", style = MaterialTheme.typography.titleMedium, modifier = Modifier.padding(top=8.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun CommissionRateCard(rate: CommissionRate, onEditClick: () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp), elevation = CardDefaults.cardElevation(2.dp)) {
+        Row(modifier = Modifier.padding(16.dp).fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(rate.key, style = MaterialTheme.typography.titleMedium)
+                Text("${rate.description} - Rate: ${rate.displayRate}")
+                rate.formattedUpdatedAt()?.let {
+                    Text("Updated: $it by ${rate.updatedBy ?: "N/A"}", style = MaterialTheme.typography.bodySmall)
+                }
+            }
+            IconButton(onClick = onEditClick) {
+                Icon(Icons.Filled.Edit, contentDescription = "Edit Rate")
+            }
+        }
+    }
+}
+
+@Composable
+fun CommissionedTransactionCard(tx: CommissionedTransaction, isPayoutView: Boolean = false) {
+    val decimalFormat = DecimalFormat("#,##0.00")
+    Card(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp), elevation = CardDefaults.cardElevation(2.dp)) {
+        Column(Modifier.padding(16.dp)) {
+            Text("TXN ID: ${tx.transactionId}", style = MaterialTheme.typography.titleSmall)
+            if(!isPayoutView) Text("Seller: ${tx.sellerId}")
+            Text("Sale: $${decimalFormat.format(tx.saleAmount)} (${tx.category}) on ${tx.formattedTransactionDate()}")
+            Text("Commission: $${decimalFormat.format(tx.commissionAmount)} (${tx.displayCommissionRateApplied} of ${tx.commissionRateKey})", color = MaterialTheme.colorScheme.primary)
+            if(!isPayoutView) Text("Payout Status: ${tx.payoutStatus}", style = MaterialTheme.typography.labelMedium)
+        }
+    }
+}
+
+@Composable
+fun EditCommissionRateDialog(rate: CommissionRate, onDismiss: () -> Unit, onSave: (String, Double, String) -> Unit) {
+    var currentRate by remember { mutableStateOf((rate.rate * 100).format(2)) } // Store as percentage string
+    var currentDesc by remember { mutableStateOf(rate.description) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Edit Commission Rate: ${rate.key}") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = currentRate,
+                    onValueChange = { currentRate = it.filter { c -> c.isDigit() || c == '.'} },
+                    label = { Text("Rate (%)") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal)
+                )
+                OutlinedTextField(
+                    value = currentDesc,
+                    onValueChange = { currentDesc = it },
+                    label = { Text("Description") }
+                )
+            }
+        },
+        confirmButton = {
+            Button(onClick = {
+                val rateValue = currentRate.toDoubleOrNull()
+                if (rateValue != null && rateValue >= 0 && rateValue <= 100) {
+                    onSave(rate.key, rateValue / 100.0, currentDesc)
+                } else {
+                    // TODO: Show error to user about invalid rate input
+                }
+            }) { Text("Save") }
+        },
+        dismissButton = { Button(onClick = onDismiss) { Text("Cancel") } }
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewCommissionManagementScreen() {
+    MaterialTheme {
+        CommissionManagementScreen(viewModel = CommissionManagementViewModel())
+    }
+}

--- a/app/src/main/java/com/example/rooster/financials/payouts/PayoutSystemScreen.kt
+++ b/app/src/main/java/com/example/rooster/financials/payouts/PayoutSystemScreen.kt
@@ -1,0 +1,327 @@
+package com.example.rooster.financials.payouts
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import java.text.DecimalFormat
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import kotlin.random.Random
+
+// --- Data Classes ---
+data class SellerBalance(
+    val sellerId: String,
+    var balance: Double
+)
+
+data class PayoutMethodDetails(
+    val method: String, // "paypal", "bank_transfer", etc.
+    val accountId: String
+)
+
+data class PayoutRequest(
+    val requestId: String,
+    val sellerId: String,
+    val amountRequested: Double,
+    val currency: String = "USD",
+    val requestedAt: Date,
+    val payoutMethodDetails: PayoutMethodDetails,
+    var status: String, // pending_approval, approved, processing, completed, rejected
+    var notes: String? = null,
+    var approvedBy: String? = null,
+    var approvedAt: Date? = null,
+    var processedBy: String? = null,
+    var processedAt: Date? = null,
+    var completedAt: Date? = null,
+    var transactionReference: String? = null
+) {
+    fun getFormattedDate(date: Date?): String =
+        date?.let { SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(it) } ?: "N/A"
+}
+
+// --- ViewModel ---
+class PayoutSystemViewModel : ViewModel() {
+    private val _sellerBalances = MutableStateFlow<List<SellerBalance>>(emptyList())
+    val sellerBalances: StateFlow<List<SellerBalance>> = _sellerBalances
+
+    private val _payoutRequests = MutableStateFlow<List<PayoutRequest>>(emptyList())
+    val payoutRequests: StateFlow<List<PayoutRequest>> = _payoutRequests // Active requests
+
+    private val _payoutHistory = MutableStateFlow<List<PayoutRequest>>(emptyList())
+    val payoutHistory: StateFlow<List<PayoutRequest>> = _payoutHistory
+
+    val pendingApprovalRequests: StateFlow<List<PayoutRequest>> = MutableStateFlow(emptyList())
+    val approvedForProcessingRequests: StateFlow<List<PayoutRequest>> = MutableStateFlow(emptyList())
+
+
+    init {
+        loadMockData()
+        updateDerivedRequestLists()
+    }
+
+    private fun loadMockData() {
+        val sIds = (1..5).map { "seller${it.toString().padStart(3, '0')}" }
+        _sellerBalances.value = sIds.map { SellerBalance(it, Random.nextDouble(50.0, 2000.0)) }
+
+        val methods = listOf("paypal", "bank_transfer", "payoneer")
+        val initialRequests = mutableListOf<PayoutRequest>()
+        val initialHistory = mutableListOf<PayoutRequest>()
+
+        for (i in 0..4) { // Pending requests
+            val sellerId = sIds.random()
+            val balance = _sellerBalances.value.first { it.sellerId == sellerId }.balance
+            if (balance < 20) continue
+            initialRequests.add(
+                PayoutRequest(
+                    requestId = "req_${Date().time}_$i",
+                    sellerId = sellerId,
+                    amountRequested = Random.nextDouble(20.0, minOf(balance, 500.0)),
+                    requestedAt = Date(System.currentTimeMillis() - Random.nextLong(0, 5 * 86400000L)),
+                    payoutMethodDetails = PayoutMethodDetails(methods.random(), "acc_${Random.nextInt(1000, 9999)}"),
+                    status = "pending_approval"
+                )
+            )
+        }
+        _payoutRequests.value = initialRequests.sortedBy { it.requestedAt }
+
+        for (i in 0..9) { // Historical payouts
+             val sellerIdHist = sIds.random()
+            initialHistory.add(
+                PayoutRequest(
+                    requestId = "hist_${Date().time - Random.nextLong(1,60) * 86400000L}_$i", // Make it distinct from requestID
+                    sellerId = sellerIdHist,
+                    amountRequested = Random.nextDouble(20.0, 500.0),
+                    requestedAt = Date(System.currentTimeMillis() - Random.nextLong(60, 120) * 86400000L), // Older request date
+                    payoutMethodDetails = PayoutMethodDetails(methods.random(), "acc_${Random.nextInt(1000, 9999)}"),
+                    status = "completed",
+                    completedAt = Date(System.currentTimeMillis() - Random.nextLong(1, 60) * 86400000L),
+                    processedBy = "admin_auto",
+                    transactionReference = "ref_${Random.nextInt(100000, 999999)}"
+                ).apply { amountRequested = this.amountRequested } // Ensure amountPaid is set in a real scenario
+            )
+        }
+        _payoutHistory.value = initialHistory.sortedByDescending { it.completedAt }
+    }
+
+    private fun updateDerivedRequestLists() {
+        (pendingApprovalRequests as MutableStateFlow).value = _payoutRequests.value.filter { it.status == "pending_approval" }
+        (approvedForProcessingRequests as MutableStateFlow).value = _payoutRequests.value.filter { it.status == "approved" }
+    }
+
+    fun approvePayoutRequest(requestId: String, adminId: String) {
+        _payoutRequests.update { requests ->
+            requests.map { req ->
+                if (req.requestId == requestId && req.status == "pending_approval") {
+                    val sellerBalance = _sellerBalances.value.firstOrNull { it.sellerId == req.sellerId }?.balance ?: 0.0
+                    if (sellerBalance >= req.amountRequested) {
+                        req.copy(status = "approved", approvedBy = adminId, approvedAt = Date())
+                    } else {
+                        req.copy(status = "rejected", notes = "Insufficient balance", processedBy = adminId, processedAt = Date())
+                    }
+                } else req
+            }
+        }
+        updateDerivedRequestLists()
+    }
+
+    fun processPayout(requestId: String, adminId: String, txnReference: String) {
+        var processedRequest: PayoutRequest? = null
+        _payoutRequests.update { requests ->
+            requests.mapNotNull { req ->
+                if (req.requestId == requestId && req.status == "approved") {
+                    processedRequest = req.copy(
+                        status = "completed", // Simulate immediate completion
+                        processedBy = adminId,
+                        processedAt = Date(),
+                        completedAt = Date(),
+                        transactionReference = txnReference
+                    )
+                    // Deduct balance
+                    _sellerBalances.update { balances ->
+                        balances.map { if (it.sellerId == processedRequest!!.sellerId) it.copy(balance = it.balance - processedRequest!!.amountRequested) else it }
+                    }
+                    null // Remove from active requests
+                } else req
+            }
+        }
+        processedRequest?.let {
+            _payoutHistory.update { history -> (listOf(it) + history).sortedByDescending { h -> h.completedAt } }
+        }
+        updateDerivedRequestLists()
+    }
+
+    fun rejectPayoutRequest(requestId: String, reason: String, adminId: String) {
+        _payoutRequests.update { requests ->
+            requests.map { req ->
+                if (req.requestId == requestId && (req.status == "pending_approval" || req.status == "approved")) {
+                    req.copy(status = "rejected", notes = reason, processedBy = adminId, processedAt = Date())
+                } else req
+            }
+        }
+        // Rejected requests could be moved to history or a separate list. Here they remain in _payoutRequests with 'rejected' status.
+        updateDerivedRequestLists()
+    }
+}
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PayoutSystemScreen(viewModel: PayoutSystemViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val sellerBalances by viewModel.sellerBalances.collectAsState()
+    val pendingApproval by viewModel.pendingApprovalRequests.collectAsState()
+    val approvedForProcessing by viewModel.approvedForProcessingRequests.collectAsState()
+    val history by viewModel.payoutHistory.collectAsState()
+
+    var showRejectDialog by remember { mutableStateOf(false) }
+    var rejectReason by remember { mutableStateOf("") }
+    var requestToReject by remember { mutableStateOf<PayoutRequest?>(null) }
+
+    if (showRejectDialog && requestToReject != null) {
+        AlertDialog(
+            onDismissRequest = { showRejectDialog = false },
+            title = { Text("Reject Payout Request") },
+            text = {
+                Column {
+                    Text("Request ID: ${requestToReject!!.requestId}")
+                    Text("Amount: $${requestToReject!!.amountRequested.format(2)}")
+                    OutlinedTextField(value = rejectReason, onValueChange = { rejectReason = it}, label = { Text("Reason for Rejection")})
+                }
+            },
+            confirmButton = {
+                Button(onClick = {
+                    viewModel.rejectPayoutRequest(requestToReject!!.requestId, rejectReason, "admin_compose")
+                    showRejectDialog = false
+                    rejectReason = ""
+                }) { Text("Confirm Rejection") }
+            },
+            dismissButton = { Button(onClick = { showRejectDialog = false }) { Text("Cancel") } }
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text("Payout System") }, colors = TopAppBarDefaults.topAppBarColors(containerColor = Color(0xFF66BB6A))) // Green
+        }
+    ) { paddingValues ->
+        LazyColumn(modifier = Modifier.padding(paddingValues).padding(16.dp)) {
+            item { SectionTitle("Seller Balances (Top 3)") }
+            items(sellerBalances.take(3)) { balance -> SellerBalanceCard(balance) }
+
+            item { SectionTitle("Pending Approval (${pendingApproval.size})") }
+            if (pendingApproval.isEmpty()) item { EmptyState("No requests pending approval.") }
+            items(pendingApproval) { req ->
+                PayoutRequestCard(req,
+                    onApprove = { viewModel.approvePayoutRequest(req.requestId, "admin_compose") },
+                    onReject = { requestToReject = req; showRejectDialog = true; }
+                )
+            }
+
+            item { SectionTitle("Approved - Ready to Process (${approvedForProcessing.size})") }
+             if (approvedForProcessing.isEmpty()) item { EmptyState("No requests ready for processing.") }
+            items(approvedForProcessing) { req ->
+                PayoutRequestCard(req,
+                    onProcess = { viewModel.processPayout(req.requestId, "admin_compose", "mock_txn_${Random.nextInt(10000)}") },
+                    onReject = { requestToReject = req; showRejectDialog = true; }
+                )
+            }
+
+            item { SectionTitle("Payout History (Last 5)") }
+            if (history.isEmpty()) item { EmptyState("No payout history.") }
+            items(history.take(5)) { hist -> PayoutHistoryCard(hist) }
+        }
+    }
+}
+
+@Composable
+fun SectionTitle(title: String) {
+    Text(title, style = MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(top = 16.dp, bottom = 8.dp))
+}
+
+@Composable
+fun EmptyState(message: String) {
+    Text(message, modifier = Modifier.padding(vertical = 8.dp))
+}
+
+@Composable
+fun SellerBalanceCard(balance: SellerBalance) {
+    Card(Modifier.fillMaxWidth().padding(vertical = 4.dp), elevation = CardDefaults.cardElevation(2.dp)) {
+        Row(Modifier.padding(16.dp), verticalAlignment = Alignment.CenterVertically) {
+            Text("Seller ID: ${balance.sellerId}", style = MaterialTheme.typography.titleMedium)
+            Spacer(Modifier.weight(1f))
+            Text("Balance: $${balance.balance.format(2)}", fontWeight = FontWeight.Bold)
+        }
+    }
+}
+
+@Composable
+fun PayoutRequestCard(
+    req: PayoutRequest,
+    onApprove: (() -> Unit)? = null,
+    onProcess: (() -> Unit)? = null,
+    onReject: (() -> Unit)? = null
+) {
+    val df = DecimalFormat("$ #,##0.00")
+    Card(Modifier.fillMaxWidth().padding(vertical = 4.dp), elevation = CardDefaults.cardElevation(2.dp)) {
+        Column(Modifier.padding(16.dp)) {
+            Text("Req ID: ${req.requestId}", style = MaterialTheme.typography.titleSmall)
+            Text("Seller: ${req.sellerId} - Amount: ${df.format(req.amountRequested)} ${req.currency}")
+            Text("Method: ${req.payoutMethodDetails.method} (${req.payoutMethodDetails.accountId})")
+            Text("Requested: ${req.getFormattedDate(req.requestedAt)}")
+            Text("Status: ${req.status}", color = when(req.status){
+                "pending_approval" -> Color.Blue
+                "approved" -> Color(0xFFFFA000) // Amber
+                "rejected" -> Color.Red
+                else -> Color.DarkGray
+            })
+            if (req.status == "rejected" && req.notes != null) Text("Notes: ${req.notes}", color = Color.Red)
+
+            Row(Modifier.padding(top = 8.dp).fillMaxWidth(), horizontalArrangement = Arrangement.End, verticalAlignment = Alignment.CenterVertically) {
+                onApprove?.let { Button(onClick = it) { Text("Approve") } }
+                onProcess?.let { Button(onClick = it, colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.secondary)) { Text("Process") } }
+                Spacer(Modifier.width(8.dp))
+                onReject?.let { Button(onClick = it, colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)) { Text("Reject") } }
+            }
+        }
+    }
+}
+
+@Composable
+fun PayoutHistoryCard(payout: PayoutRequest) {
+     val df = DecimalFormat("$ #,##0.00")
+    Card(Modifier.fillMaxWidth().padding(vertical = 4.dp), elevation = CardDefaults.cardElevation(1.dp)) {
+        Column(Modifier.padding(16.dp)) {
+            Text("ID: ${payout.transactionReference ?: payout.requestId}", style = MaterialTheme.typography.titleSmall)
+            Text("Seller: ${payout.sellerId} - Amount: ${df.format(payout.amountRequested)} ${payout.currency}")
+            Text("Status: ${payout.status}", fontWeight = FontWeight.Bold)
+            Text("Method: ${payout.payoutMethodDetails.method}")
+            Text("Completed: ${payout.getFormattedDate(payout.completedAt)}")
+            payout.transactionReference?.let { Text("Reference: $it") }
+        }
+    }
+}
+
+// Double.format extension from CommissionManagementScreen, ensure it's accessible or redefine.
+// For simplicity, assuming it's available or this file is part of the same module/scope.
+// If not, uncomment and use this:
+// fun Double.format(digits: Int) = "%.${digits}f".format(this)
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewPayoutSystemScreen() {
+    MaterialTheme {
+        PayoutSystemScreen(viewModel = PayoutSystemViewModel())
+    }
+}

--- a/app/src/main/java/com/example/rooster/financials/reports/FinancialReportsScreen.kt
+++ b/app/src/main/java/com/example/rooster/financials/reports/FinancialReportsScreen.kt
@@ -1,0 +1,278 @@
+package com.example.rooster.financials.reports
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import java.text.DecimalFormat
+import java.util.Calendar
+import kotlin.random.Random
+
+// --- Data Classes ---
+// Using Map<String, Double> for simplicity, similar to Python. Could be more structured.
+data class FinancialReportData(
+    val year: Int,
+    val month: Int,
+    val revenue: Map<String, Double>,
+    val totalRevenue: Double,
+    val costOfGoodsSold: Map<String, Double>,
+    val totalCogs: Double,
+    val grossProfit: Double,
+    val operatingExpenses: Map<String, Double>,
+    val totalOperatingExpenses: Double,
+    val operatingIncome: Double, // EBIT
+    val nonOperating: Map<String, Double>, // Interest, Taxes
+    val netIncome: Double,
+    // Balance Sheet parts
+    val currentAssets: Map<String, Double>,
+    val totalCurrentAssets: Double,
+    val nonCurrentAssets: Map<String, Double>,
+    val totalNonCurrentAssets: Double,
+    val totalAssets: Double,
+    val currentLiabilities: Map<String, Double>,
+    val totalCurrentLiabilities: Double,
+    val nonCurrentLiabilities: Map<String, Double>,
+    val totalNonCurrentLiabilities: Double,
+    val totalLiabilities: Double,
+    val equity: Map<String, Double>, // Placeholder for actual equity components
+    val totalEquity: Double
+)
+
+// --- ViewModel ---
+class FinancialReportsViewModel : ViewModel() {
+    private val _financialReportData = MutableStateFlow<FinancialReportData?>(null)
+    val financialReportData: StateFlow<FinancialReportData?> = _financialReportData
+
+    init {
+        loadMockFinancialData()
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun loadMockFinancialData() {
+        val today = Calendar.getInstance()
+        val year = today.get(Calendar.YEAR)
+        val month = today.get(Calendar.MONTH) + 1 // Calendar.MONTH is 0-indexed
+
+        val revenueMap = mapOf(
+            "consultation_fees" to Random.nextDouble(50000.0, 150000.0),
+            "marketplace_commissions" to Random.nextDouble(30000.0, 100000.0),
+            "subscription_fees" to Random.nextDouble(10000.0, 50000.0),
+            "other_income" to Random.nextDouble(1000.0, 5000.0)
+        )
+        val totalRevenue = revenueMap.values.sum()
+
+        val cogsMap = mapOf(
+            "platform_service_costs" to totalRevenue * Random.nextDouble(0.05, 0.10)
+        )
+        val totalCogs = cogsMap.values.sum()
+        val grossProfit = totalRevenue - totalCogs
+
+        val opExpensesMap = mapOf(
+            "salaries_and_wages" to Random.nextDouble(20000.0, 60000.0),
+            "marketing_and_advertising" to Random.nextDouble(5000.0, 20000.0),
+            "software_and_tools" to Random.nextDouble(2000.0, 10000.0),
+            "rent_and_utilities" to Random.nextDouble(1000.0, 5000.0),
+            "payment_processing_fees" to totalRevenue * Random.nextDouble(0.01, 0.03),
+            "customer_support" to Random.nextDouble(3000.0, 8000.0),
+            "other_operating_expenses" to Random.nextDouble(1000.0, 4000.0)
+        )
+        val totalOpExpenses = opExpensesMap.values.sum()
+        val operatingIncome = grossProfit - totalOpExpenses
+
+        val nonOpMap = mapOf(
+            "interest_expense" to (if (operatingIncome > 0) operatingIncome * Random.nextDouble(0.0, 0.02) else 0.0),
+            "taxes" to (if (operatingIncome > 0) operatingIncome * Random.nextDouble(0.1, 0.2) else 0.0)
+        )
+        val netIncome = operatingIncome - nonOpMap.values.sum()
+
+        // Balance Sheet
+        val currentAssetsMap = mapOf(
+            "cash_and_equivalents" to Random.nextDouble(100000.0, 500000.0),
+            "accounts_receivable" to totalRevenue * Random.nextDouble(0.1, 0.2),
+            "prepaid_expenses" to Random.nextDouble(5000.0, 20000.0)
+        )
+        val totalCurrentAssets = currentAssetsMap.values.sum()
+        val nonCurrentAssetsMap = mapOf(
+            "property_plant_equipment_net" to Random.nextDouble(20000.0, 100000.0),
+            "intangible_assets_net" to Random.nextDouble(10000.0, 50000.0)
+        )
+        val totalNonCurrentAssets = nonCurrentAssetsMap.values.sum()
+        val totalAssets = totalCurrentAssets + totalNonCurrentAssets
+
+        val currentLiabilitiesMap = mapOf(
+            "accounts_payable" to totalOpExpenses * Random.nextDouble(0.1, 0.15),
+            "deferred_revenue" to revenueMap.getOrDefault("subscription_fees", 0.0) * Random.nextDouble(0.2, 0.4),
+            "accrued_expenses" to Random.nextDouble(3000.0, 15000.0)
+        )
+        val totalCurrentLiabilities = currentLiabilitiesMap.values.sum()
+        val nonCurrentLiabilitiesMap = mapOf(
+            "long_term_debt" to Random.nextDouble(0.0, 50000.0)
+        )
+        val totalNonCurrentLiabilities = nonCurrentLiabilitiesMap.values.sum()
+        val totalLiabilities = totalCurrentLiabilities + totalNonCurrentLiabilities
+
+        val totalEquity = totalAssets - totalLiabilities
+        val equityMap = mapOf(
+            "retained_earnings_placeholder" to totalEquity - 50000.0, // Assuming 50k common stock
+            "common_stock_placeholder" to 50000.0
+        )
+
+
+        _financialReportData.value = FinancialReportData(
+            year, month, revenueMap, totalRevenue, cogsMap, totalCogs, grossProfit,
+            opExpensesMap, totalOpExpenses, operatingIncome, nonOpMap, netIncome,
+            currentAssetsMap, totalCurrentAssets, nonCurrentAssetsMap, totalNonCurrentAssets, totalAssets,
+            currentLiabilitiesMap, totalCurrentLiabilities, nonCurrentLiabilitiesMap, totalNonCurrentLiabilities, totalLiabilities,
+            equityMap, totalEquity
+        )
+    }
+}
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FinancialReportsScreen(viewModel: FinancialReportsViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val reportData by viewModel.financialReportData.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Financial Reports") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color(0xFF42A5F5)) // Blue
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(modifier = Modifier.padding(paddingValues).padding(16.dp)) {
+            reportData?.let { data ->
+                item { ProfitAndLossStatement(data) }
+                item { Spacer(modifier = Modifier.height(24.dp)) }
+                item { BalanceSheetSummary(data) }
+            } ?: item {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = androidx.compose.ui.Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            }
+        }
+    }
+}
+
+val decimalFormat = DecimalFormat("$ #,##0.00;($ #,##0.00)") // Positive;Negative format
+
+@Composable
+fun ReportRow(label: String, amount: Double?, isTotal: Boolean = false, indentLevel: Int = 0) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(start = (indentLevel * 16).dp, vertical = 2.dp),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = label.replace("_", " ").replaceFirstChar { it.titlecase() },
+            fontWeight = if (isTotal) FontWeight.Bold else FontWeight.Normal,
+            fontSize = if (isTotal) 15.sp else 14.sp
+        )
+        Text(
+            text = amount?.let { decimalFormat.format(it) } ?: "-",
+            fontWeight = if (isTotal) FontWeight.Bold else FontWeight.Normal,
+            fontSize = if (isTotal) 15.sp else 14.sp
+        )
+    }
+}
+
+@Composable
+fun ReportSectionHeader(title: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleMedium,
+        modifier = Modifier.padding(top = 12.dp, bottom = 6.dp)
+    )
+}
+
+
+@Composable
+fun ProfitAndLossStatement(data: FinancialReportData) {
+    Card(elevation = CardDefaults.cardElevation(2.dp), modifier = Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp)) {
+            Text("Profit and Loss Statement", style = MaterialTheme.typography.headlineSmall)
+            Text("For Period Ending: ${data.month}/${data.year}", style = MaterialTheme.typography.bodySmall)
+            Divider(modifier = Modifier.padding(vertical = 8.dp))
+
+            ReportSectionHeader("Revenue")
+            data.revenue.forEach { (key, value) -> ReportRow(key, value, indentLevel = 1) }
+            ReportRow("Total Revenue", data.totalRevenue, isTotal = true)
+
+            ReportSectionHeader("Cost of Goods Sold")
+            data.costOfGoodsSold.forEach { (key, value) -> ReportRow(key, value, indentLevel = 1) }
+            ReportRow("Total COGS", data.totalCogs, isTotal = true)
+            ReportRow("Gross Profit", data.grossProfit, isTotal = true, indentLevel = -1) // Negative indent to align with major totals
+
+            ReportSectionHeader("Operating Expenses")
+            data.operatingExpenses.forEach { (key, value) -> ReportRow(key, value, indentLevel = 1) }
+            ReportRow("Total Operating Expenses", data.totalOperatingExpenses, isTotal = true)
+            ReportRow("Operating Income (EBIT)", data.operatingIncome, isTotal = true, indentLevel = -1)
+
+            ReportSectionHeader("Non-Operating Income/Expenses")
+            data.nonOperating.forEach { (key, value) -> ReportRow(key, value, indentLevel = 1) }
+            ReportRow("Net Income", data.netIncome, isTotal = true, indentLevel = -1)
+        }
+    }
+}
+
+@Composable
+fun BalanceSheetSummary(data: FinancialReportData) {
+    Card(elevation = CardDefaults.cardElevation(2.dp), modifier = Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp)) {
+            Text("Balance Sheet Summary", style = MaterialTheme.typography.headlineSmall)
+            Text("As of: ${data.month}/${data.year}", style = MaterialTheme.typography.bodySmall)
+            Divider(modifier = Modifier.padding(vertical = 8.dp))
+
+            ReportSectionHeader("Assets")
+            ReportSectionHeader("Current Assets")
+            data.currentAssets.forEach { (key, value) -> ReportRow(key, value, indentLevel = 2) }
+            ReportRow("Total Current Assets", data.totalCurrentAssets, isTotal = true, indentLevel = 1)
+
+            ReportSectionHeader("Non-Current Assets")
+            data.nonCurrentAssets.forEach { (key, value) -> ReportRow(key, value, indentLevel = 2) }
+            ReportRow("Total Non-Current Assets", data.totalNonCurrentAssets, isTotal = true, indentLevel = 1)
+            ReportRow("Total Assets", data.totalAssets, isTotal = true)
+
+            ReportSectionHeader("Liabilities")
+            ReportSectionHeader("Current Liabilities")
+            data.currentLiabilities.forEach { (key, value) -> ReportRow(key, value, indentLevel = 2) }
+            ReportRow("Total Current Liabilities", data.totalCurrentLiabilities, isTotal = true, indentLevel = 1)
+
+            ReportSectionHeader("Non-Current Liabilities")
+            data.nonCurrentLiabilities.forEach { (key, value) -> ReportRow(key, value, indentLevel = 2) }
+            ReportRow("Total Non-Current Liabilities", data.totalNonCurrentLiabilities, isTotal = true, indentLevel = 1)
+            ReportRow("Total Liabilities", data.totalLiabilities, isTotal = true)
+
+            ReportSectionHeader("Equity")
+            data.equity.forEach { (key, value) -> ReportRow(key, value, indentLevel = 1) }
+            ReportRow("Total Equity", data.totalEquity, isTotal = true)
+            Divider(modifier = Modifier.padding(vertical = 4.dp))
+            ReportRow("Total Liabilities and Equity", data.totalLiabilities + data.totalEquity, isTotal = true)
+
+            // Sanity Check (visual cue, actual logic would be in VM or tests)
+            if (kotlin.math.abs((data.totalLiabilities + data.totalEquity) - data.totalAssets) > 0.01) {
+                Text("Error: Balance sheet does not balance!", color = Color.Red, fontWeight = FontWeight.Bold)
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewFinancialReportsScreen() {
+    MaterialTheme {
+        FinancialReportsScreen(viewModel = FinancialReportsViewModel())
+    }
+}

--- a/app/src/main/java/com/example/rooster/financials/revenueanalytics/RevenueAnalyticsScreen.kt
+++ b/app/src/main/java/com/example/rooster/financials/revenueanalytics/RevenueAnalyticsScreen.kt
@@ -1,0 +1,212 @@
+package com.example.rooster.financials.revenueanalytics
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import java.text.DecimalFormat
+import java.util.Calendar
+import kotlin.random.Random
+
+// --- Data Classes ---
+// Using Map<String, Any> for flexibility, mirroring Python's dictionary structure.
+// For a production app, more specific data classes would be better.
+data class RevenueSummary(val metrics: Map<String, Any>)
+data class RevenueBySource(val periodData: Map<String, Map<String, Double>>) // MTD/YTD -> Source -> Amount
+data class RevenueTrendPoint(val label: String, val revenue: Double) // Date or Month string
+data class RevenueTrend(val granularity: String, val points: List<RevenueTrendPoint>)
+data class ClvData(val segments: Map<String, Double>)
+data class TopRevenueItem(val name: String, val type: String, val revenueMtd: Double)
+
+// --- ViewModel ---
+class RevenueAnalyticsViewModel : ViewModel() {
+    private val _summary = MutableStateFlow<RevenueSummary?>(null)
+    val summary: StateFlow<RevenueSummary?> = _summary
+
+    private val _revenueBySource = MutableStateFlow<RevenueBySource?>(null)
+    val revenueBySource: StateFlow<RevenueBySource?> = _revenueBySource
+
+    private val _dailyTrend = MutableStateFlow<RevenueTrend?>(null)
+    val dailyTrend: StateFlow<RevenueTrend?> = _dailyTrend
+
+    private val _monthlyTrend = MutableStateFlow<RevenueTrend?>(null)
+    val monthlyTrend: StateFlow<RevenueTrend?> = _monthlyTrend
+
+    private val _clv = MutableStateFlow<ClvData?>(null)
+    val clv: StateFlow<ClvData?> = _clv
+
+    private val _topItems = MutableStateFlow<List<TopRevenueItem>>(emptyList())
+    val topItems: StateFlow<List<TopRevenueItem>> = _topItems
+
+    init {
+        loadMockRevenueData()
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun loadMockRevenueData() {
+        val sources = listOf("Consultation Fees", "Marketplace Commissions", "Subscription Fees", "Premium Content Sales")
+        val revenueBySourceMtd = sources.associateWith { Random.nextDouble(1000.0, 10000.0) }
+        val revenueBySourceYtd = revenueBySourceMtd.mapValues { it.value * Random.nextDouble(8.0, 12.0) }
+
+        val totalRevenueMtd = revenueBySourceMtd.values.sum()
+        val totalRevenueYtd = revenueBySourceYtd.values.sum()
+
+        _summary.value = RevenueSummary(mapOf(
+            "total_revenue_mtd" to totalRevenueMtd,
+            "total_revenue_ytd" to totalRevenueYtd,
+            "average_revenue_per_paying_user_arppu_monthly" to totalRevenueMtd / (1000 + Random.nextInt(-100, 100)),
+            "churn_rate_monthly" to "${Random.nextDouble(1.5, 5.0).format(2)}%"
+        ))
+
+        _revenueBySource.value = RevenueBySource(mapOf("mtd" to revenueBySourceMtd, "ytd" to revenueBySourceYtd))
+
+        val today = Calendar.getInstance()
+        val dailyPoints = (0..29).map { i ->
+            val day = today.clone() as Calendar
+            day.add(Calendar.DATE, -i)
+            RevenueTrendPoint(
+                label = "${day.get(Calendar.YEAR)}-${day.get(Calendar.MONTH) + 1}-${day.get(Calendar.DAY_OF_MONTH)}",
+                revenue = sources.sumOf { Random.nextDouble(50.0, 200.0) }
+            )
+        }.reversed()
+        _dailyTrend.value = RevenueTrend("Daily", dailyPoints)
+
+        val monthlyPoints = (0..11).map { i ->
+            val currentMonthCal = today.clone() as Calendar
+            currentMonthCal.add(Calendar.MONTH, -i)
+            RevenueTrendPoint(
+                label = "${currentMonthCal.get(Calendar.YEAR)}-${currentMonthCal.get(Calendar.MONTH) + 1}",
+                revenue = sources.sumOf { Random.nextDouble(5000.0, 20000.0) }
+            )
+        }.reversed()
+        _monthlyTrend.value = RevenueTrend("Monthly", monthlyPoints)
+
+        _clv.value = ClvData(mapOf(
+            "farmers_standard" to Random.nextDouble(50.0, 150.0),
+            "farmers_premium" to Random.nextDouble(150.0, 400.0),
+            "veterinarians_basic" to Random.nextDouble(100.0, 250.0),
+            "veterinarians_pro" to Random.nextDouble(250.0, 600.0),
+            "overall_average" to (List(4) { Random.nextDouble(50.0, 600.0) }).average()
+        ))
+
+        _topItems.value = listOf(
+            TopRevenueItem("consult_specialist_A", "Consultation", Random.nextDouble(500.0, 1500.0)),
+            TopRevenueItem("product_feed_B", "Marketplace", Random.nextDouble(300.0, 1000.0)),
+            TopRevenueItem("subscription_vet_pro", "Subscription", Random.nextDouble(1000.0, 2000.0))
+        )
+    }
+    // Helper extension for formatting
+    fun Double.format(digits: Int) = "%.${digits}f".format(this)
+}
+
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RevenueAnalyticsScreen(viewModel: RevenueAnalyticsViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val summary by viewModel.summary.collectAsState()
+    val revenueBySource by viewModel.revenueBySource.collectAsState()
+    val dailyTrend by viewModel.dailyTrend.collectAsState()
+    val monthlyTrend by viewModel.monthlyTrend.collectAsState()
+    val clv by viewModel.clv.collectAsState()
+    val topItems by viewModel.topItems.collectAsState()
+
+    val decimalFormat = remember { DecimalFormat("$ #,##0.00") }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Revenue Analytics") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color(0xFFAB47BC)) // Purple
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(modifier = Modifier.padding(paddingValues).padding(16.dp)) {
+            summary?.let { item { RevenueSectionCard("Revenue Summary", it.metrics, decimalFormat) } }
+            revenueBySource?.let {
+                item { RevenueSectionCard("Revenue by Source (MTD)", it.periodData["mtd"] ?: emptyMap(), decimalFormat) }
+                item { RevenueSectionCard("Revenue by Source (YTD)", it.periodData["ytd"] ?: emptyMap(), decimalFormat) }
+            }
+            dailyTrend?.let { item { RevenueTrendCard("Daily Revenue Trend (Last 5 Days)", it.points.takeLast(5), decimalFormat) } }
+            monthlyTrend?.let { item { RevenueTrendCard("Monthly Revenue Trend (Last 3 Months)", it.points.takeLast(3), decimalFormat) } }
+            clv?.let { item { RevenueSectionCard("Customer Lifetime Value (CLV)", it.segments, decimalFormat) } }
+            if (topItems.isNotEmpty()) {
+                item { TopRevenueItemsCard(topItems, decimalFormat) }
+            }
+        }
+    }
+}
+
+@Composable
+fun RevenueSectionCard(title: String, metrics: Map<String, Any>, formatter: DecimalFormat) {
+    Card(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp), elevation = CardDefaults.cardElevation(2.dp)) {
+        Column(Modifier.padding(16.dp)) {
+            Text(title, style = MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(bottom = 8.dp))
+            DisplayRevenueMetrics(metrics, formatter)
+        }
+    }
+}
+
+@Composable
+fun DisplayRevenueMetrics(metrics: Map<String, Any>, formatter: DecimalFormat, indentLevel: Int = 0) {
+    val indent = "  ".repeat(indentLevel)
+    metrics.forEach { (key, value) ->
+        val displayKey = key.replace("_", " ").replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
+        when (value) {
+            is Map<*, *> -> {
+                Text("$indent$displayKey:")
+                DisplayRevenueMetrics(value as Map<String, Any>, formatter, indentLevel + 1)
+            }
+            is Double -> Text("$indent$displayKey: ${formatter.format(value)}")
+            is Number -> Text("$indent$displayKey: $value") // For counts or non-currency numbers
+            else -> Text("$indent$displayKey: $value")
+        }
+    }
+}
+
+@Composable
+fun RevenueTrendCard(title: String, points: List<RevenueTrendPoint>, formatter: DecimalFormat) {
+    Card(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp), elevation = CardDefaults.cardElevation(2.dp)) {
+        Column(Modifier.padding(16.dp)) {
+            Text(title, style = MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(bottom = 8.dp))
+            points.forEach { point ->
+                Text("  ${point.label}: ${formatter.format(point.revenue)}")
+            }
+            // Placeholder for chart
+            // Text("Chart would be here", textAlign = androidx.compose.ui.text.style.TextAlign.Center, modifier = Modifier.fillMaxWidth().padding(top=8.dp))
+        }
+    }
+}
+
+@Composable
+fun TopRevenueItemsCard(items: List<TopRevenueItem>, formatter: DecimalFormat) {
+    Card(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp), elevation = CardDefaults.cardElevation(2.dp)) {
+        Column(Modifier.padding(16.dp)) {
+            Text("Top Revenue Generating Items (MTD)", style = MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(bottom = 8.dp))
+            items.forEach { item ->
+                Text("  ${item.name.replace("_", " ").titlecase()} (${item.type}): ${formatter.format(item.revenueMtd)}")
+            }
+        }
+    }
+}
+
+// String.titlecase() helper if not available or for specific locale
+fun String.titlecase(): String = replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
+
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewRevenueAnalyticsScreen() {
+    MaterialTheme {
+        RevenueAnalyticsScreen(viewModel = RevenueAnalyticsViewModel())
+    }
+}

--- a/app/src/main/java/com/example/rooster/financials/transactions/TransactionMonitoringScreen.kt
+++ b/app/src/main/java/com/example/rooster/financials/transactions/TransactionMonitoringScreen.kt
@@ -1,0 +1,318 @@
+package com.example.rooster.financials.transactions
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Flag
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.update
+import java.text.DecimalFormat
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import kotlin.random.Random
+
+// --- Data Classes ---
+data class ManualReviewFlag(
+    val reason: String,
+    val adminId: String,
+    val timestamp: Date
+) {
+    fun getFormattedTimestamp(): String = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(timestamp)
+}
+
+data class Transaction(
+    val transactionId: String,
+    val timestamp: Date,
+    val userId: String,
+    val amount: Double,
+    val currency: String = "USD",
+    val paymentMethod: String,
+    val status: String, // completed, pending, failed, refunded, disputed
+    val transactionType: String,
+    val description: String,
+    val fraudFlags: List<String>,
+    val ipAddress: String,
+    val originalTransactionId: String? = null,
+    var manualReviewFlags: MutableList<ManualReviewFlag> = mutableListOf()
+) {
+    fun getFormattedTimestamp(): String = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault()).format(timestamp)
+}
+
+// --- Filter State ---
+data class TransactionFilters(
+    val status: String? = null,
+    val userId: String? = null,
+    val minAmount: Double? = null,
+    val hasFraudFlags: Boolean? = null // null = any, true = has flags, false = no flags
+)
+
+// --- ViewModel ---
+class TransactionMonitoringViewModel : ViewModel() {
+    private val _allTransactions = MutableStateFlow<List<Transaction>>(emptyList())
+
+    private val _filters = MutableStateFlow(TransactionFilters())
+    val filters: StateFlow<TransactionFilters> = _filters
+
+    val filteredTransactions: StateFlow<List<Transaction>> = combine(_allTransactions, _filters) { transactions, filters ->
+        transactions.filter { tx ->
+            (filters.status == null || tx.status.equals(filters.status, ignoreCase = true)) &&
+            (filters.userId == null || tx.userId.equals(filters.userId, ignoreCase = true)) &&
+            (filters.minAmount == null || tx.amount >= filters.minAmount) &&
+            (filters.hasFraudFlags == null || (filters.hasFraudFlags == true && tx.fraudFlags.isNotEmpty()) || (filters.hasFraudFlags == false && tx.fraudFlags.isEmpty()))
+        }.sortedByDescending { it.timestamp }
+    }.stateIn(kotlinx.coroutines.MainScope(), kotlinx.coroutines.flow.SharingStarted.WhileSubscribed(5000), emptyList())
+
+
+    init {
+        loadMockTransactions()
+    }
+
+    private fun loadMockTransactions(count: Int = 50) {
+        val paymentMethods = listOf("credit_card", "paypal", "bank_transfer", "crypto")
+        val statuses = listOf("completed", "pending", "failed", "refunded", "disputed")
+        val txTypes = listOf("consultation_fee", "marketplace_sale", "subscription", "payout_fee", "refund")
+        val userIds = (1..5).map { "user${it.toString().padStart(3, '0')}" }
+        val productIds = (1..3).map { "prod${it.toString().padStart(3, '0')}" }
+        val now = System.currentTimeMillis()
+
+        val tempTransactions = mutableListOf<Transaction>()
+        for (i in 0 until count) {
+            val amount = Random.nextDouble(5.0, 500.0)
+            val status = statuses.random()
+            val fraudFlags = mutableListOf<String>()
+            if (amount > 400 && Random.nextBoolean()) fraudFlags.add("high_value_transaction")
+            if (status == "failed" && Random.nextDouble() < 0.2) fraudFlags.add("multiple_failed_attempts_suspected")
+            if (Random.nextDouble() < 0.05) fraudFlags.add("unusual_location_match")
+
+            tempTransactions.add(
+                Transaction(
+                    transactionId = "txn_${now - Random.nextLong(0, 30 * 86400000L * 24 * 60)}_$i",
+                    timestamp = Date(now - Random.nextLong(0, 30 * 86400000L)),
+                    userId = userIds.random(),
+                    amount = amount,
+                    paymentMethod = paymentMethods.random(),
+                    status = status,
+                    transactionType = txTypes.random(),
+                    description = "${txTypes.random().replace('_', ' ').titlecase()} for ${if (txTypes.last().contains("sale")) productIds.random() else userIds.random()}",
+                    fraudFlags = fraudFlags,
+                    ipAddress = "192.168.1.${Random.nextInt(1, 254)}",
+                    originalTransactionId = if (status == "refunded") "txn_orig_${Random.nextInt(1000)}" else null
+                )
+            )
+        }
+        _allTransactions.value = tempTransactions
+    }
+
+    fun updateFilters(newFilters: TransactionFilters) {
+        _filters.value = newFilters
+    }
+
+    fun flagTransactionForReview(transactionId: String, reason: String, adminId: String) {
+        _allTransactions.update { transactions ->
+            transactions.map {
+                if (it.transactionId == transactionId) {
+                    it.copy(manualReviewFlags = (it.manualReviewFlags + ManualReviewFlag(reason, adminId, Date())).toMutableList())
+                } else it
+            }
+        }
+    }
+}
+// Helper for title case if needed elsewhere
+fun String.titlecase(): String = replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
+
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TransactionMonitoringScreen(viewModel: TransactionMonitoringViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val transactions by viewModel.filteredTransactions.collectAsState()
+    val currentFilters by viewModel.filters.collectAsState()
+
+    var showFilterDialog by remember { mutableStateOf(false) }
+    var showFlagDialog by remember { mutableStateOf(false) }
+    var transactionToFlag by remember { mutableStateOf<Transaction?>(null) }
+    var flagReason by remember { mutableStateOf("") }
+
+    if (showFilterDialog) {
+        FilterDialog(
+            currentFilters = currentFilters,
+            onDismiss = { showFilterDialog = false },
+            onApplyFilters = { newFilters ->
+                viewModel.updateFilters(newFilters)
+                showFilterDialog = false
+            }
+        )
+    }
+
+    if (showFlagDialog && transactionToFlag != null) {
+        FlagTransactionDialog(
+            transaction = transactionToFlag!!,
+            reason = flagReason,
+            onReasonChange = { flagReason = it },
+            onDismiss = { showFlagDialog = false; transactionToFlag = null; flagReason = "" },
+            onConfirm = {
+                viewModel.flagTransactionForReview(transactionToFlag!!.transactionId, flagReason, "admin_compose")
+                showFlagDialog = false
+                transactionToFlag = null
+                flagReason = ""
+            }
+        )
+    }
+
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Transaction Monitoring") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color(0xFF78909C)), // Blue Grey
+                actions = {
+                    IconButton(onClick = { showFilterDialog = true }) {
+                        Icon(Icons.Filled.Search, contentDescription = "Filter Transactions")
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(modifier = Modifier.padding(paddingValues).padding(horizontal = 16.dp, vertical = 8.dp)) {
+            if (transactions.isEmpty()){
+                item {
+                    Box(modifier = Modifier.fillParentMaxSize(), contentAlignment = Alignment.Center) {
+                        Text("No transactions match current filters.")
+                    }
+                }
+            } else {
+                items(transactions, key = { it.transactionId }) { tx ->
+                    TransactionCard(tx) {
+                        transactionToFlag = tx
+                        showFlagDialog = true
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun TransactionCard(tx: Transaction, onFlagClick: () -> Unit) {
+    val df = remember { DecimalFormat("$ #,##0.00") }
+    Card(modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp), elevation = CardDefaults.cardElevation(2.dp)) {
+        Column(Modifier.padding(12.dp)) {
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween){
+                Text(tx.transactionId, style = MaterialTheme.typography.titleSmall)
+                IconButton(onClick = onFlagClick, modifier = Modifier.size(24.dp)) {
+                    Icon(Icons.Filled.Flag, "Flag for Review", tint = if (tx.manualReviewFlags.isNotEmpty()) Color.Red else Color.Gray)
+                }
+            }
+            Text("User: ${tx.userId}, Amount: ${df.format(tx.amount)} ${tx.currency}")
+            Text("Type: ${tx.transactionType.titlecase()}, Method: ${tx.paymentMethod.titlecase()}")
+            Text("Status: ${tx.status.titlecase()}", color = when(tx.status){
+                "completed" -> Color.Green
+                "pending" -> Color.Blue
+                "failed" -> Color.Red
+                "refunded" -> Color.Magenta
+                "disputed" -> Color.Yellow // Choose appropriate color
+                else -> Color.DarkGray
+            })
+            Text("Time: ${tx.getFormattedTimestamp()}, IP: ${tx.ipAddress}")
+            if (tx.fraudFlags.isNotEmpty()) {
+                Text("Fraud Flags: ${tx.fraudFlags.joinToString()}", color = MaterialTheme.colorScheme.error, fontWeight = FontWeight.Bold)
+            }
+            tx.manualReviewFlags.lastOrNull()?.let {
+                 Text("Manual Review: ${it.reason} by ${it.adminId} at ${it.getFormattedTimestamp()}", color = Color.Red, style = MaterialTheme.typography.bodySmall)
+            }
+        }
+    }
+}
+
+@Composable
+fun FilterDialog(
+    currentFilters: TransactionFilters,
+    onDismiss: () -> Unit,
+    onApplyFilters: (TransactionFilters) -> Unit
+) {
+    var status by remember { mutableStateOf(currentFilters.status ?: "") }
+    var userId by remember { mutableStateOf(currentFilters.userId ?: "") }
+    var minAmount by remember { mutableStateOf(currentFilters.minAmount?.toString() ?: "") }
+    var hasFraudFlags by remember { mutableStateOf(currentFilters.hasFraudFlags) } // null, true, false
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Filter Transactions") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(value = status, onValueChange = { status = it }, label = { Text("Status (e.g., completed)") })
+                OutlinedTextField(value = userId, onValueChange = { userId = it }, label = { Text("User ID") })
+                OutlinedTextField(value = minAmount, onValueChange = { minAmount = it.filter{c -> c.isDigit() || c == '.'} }, label = { Text("Min Amount") })
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text("Fraud Flags: ")
+                    Spacer(Modifier.width(8.dp))
+                    RadioButton(selected = hasFraudFlags == true, onClick = { hasFraudFlags = true })
+                    Text("Yes")
+                    Spacer(Modifier.width(8.dp))
+                    RadioButton(selected = hasFraudFlags == false, onClick = { hasFraudFlags = false })
+                    Text("No")
+                     Spacer(Modifier.width(8.dp))
+                    RadioButton(selected = hasFraudFlags == null, onClick = { hasFraudFlags = null })
+                    Text("Any")
+                }
+            }
+        },
+        confirmButton = {
+            Button(onClick = {
+                onApplyFilters(TransactionFilters(
+                    status = status.ifBlank { null },
+                    userId = userId.ifBlank { null },
+                    minAmount = minAmount.toDoubleOrNull(),
+                    hasFraudFlags = hasFraudFlags
+                ))
+            }) { Text("Apply") }
+        },
+        dismissButton = { Button(onClick = onDismiss) { Text("Cancel") } }
+    )
+}
+
+@Composable
+fun FlagTransactionDialog(
+    transaction: Transaction,
+    reason: String,
+    onReasonChange: (String) -> Unit,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Flag Transaction: ${transaction.transactionId}") },
+        text = {
+            OutlinedTextField(
+                value = reason,
+                onValueChange = onReasonChange,
+                label = { Text("Reason for flagging") },
+                modifier = Modifier.fillMaxWidth()
+            )
+        },
+        confirmButton = { Button(onClick = onConfirm, enabled = reason.isNotBlank()) { Text("Flag") } },
+        dismissButton = { Button(onClick = onDismiss) { Text("Cancel") } }
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewTransactionMonitoringScreen() {
+    MaterialTheme {
+        TransactionMonitoringScreen(viewModel = TransactionMonitoringViewModel())
+    }
+}

--- a/app/src/main/java/com/example/rooster/professionaltools/ProfessionalToolsDashboardScreen.kt
+++ b/app/src/main/java/com/example/rooster/professionaltools/ProfessionalToolsDashboardScreen.kt
@@ -1,0 +1,84 @@
+package com.example.rooster.professionaltools
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.example.rooster.professionaltools.casestudies.CaseStudyScreen
+import com.example.rooster.professionaltools.diagnosisassistant.DiagnosisAssistantScreen
+import com.example.rooster.professionaltools.educationalcontent.EducationalContentScreen
+import com.example.rooster.professionaltools.vetnetwork.VeterinaryNetworkScreen
+
+object ProfessionalToolsDestinations {
+    const val DASHBOARD = "professional_tools_dashboard"
+    const val CASE_STUDIES = "professional_tools_case_studies"
+    const val DIAGNOSIS_ASSISTANT = "professional_tools_diagnosis_assistant"
+    const val EDUCATIONAL_CONTENT = "professional_tools_educational_content"
+    const val VETERINARY_NETWORK = "professional_tools_veterinary_network"
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProfessionalToolsDashboardScreen(navController: NavController) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Professional Tools Dashboard") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color(0xFF0D47A1)) // Dark Blue
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxSize()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            item { ProfessionalToolsDashboardButton(navController, "Case Studies", ProfessionalToolsDestinations.CASE_STUDIES) }
+            item { ProfessionalToolsDashboardButton(navController, "Diagnosis Assistant", ProfessionalToolsDestinations.DIAGNOSIS_ASSISTANT) }
+            item { ProfessionalToolsDashboardButton(navController, "Educational Content", ProfessionalToolsDestinations.EDUCATIONAL_CONTENT) }
+            item { ProfessionalToolsDashboardButton(navController, "Veterinary Network", ProfessionalToolsDestinations.VETERINARY_NETWORK) }
+        }
+    }
+}
+
+@Composable
+fun ProfessionalToolsDashboardButton(navController: NavController, text: String, route: String) {
+    Button(
+        onClick = { navController.navigate(route) },
+        modifier = Modifier.fillMaxWidth(0.8f).height(50.dp)
+    ) {
+        Text(text)
+    }
+}
+
+@Composable
+fun ProfessionalToolsFeatureNavigator() {
+    val navController = rememberNavController()
+    NavHost(navController = navController, startDestination = ProfessionalToolsDestinations.DASHBOARD) {
+        composable(ProfessionalToolsDestinations.DASHBOARD) { ProfessionalToolsDashboardScreen(navController) }
+        composable(ProfessionalToolsDestinations.CASE_STUDIES) { CaseStudyScreen() }
+        composable(ProfessionalToolsDestinations.DIAGNOSIS_ASSISTANT) { DiagnosisAssistantScreen() }
+        composable(ProfessionalToolsDestinations.EDUCATIONAL_CONTENT) { EducationalContentScreen() }
+        composable(ProfessionalToolsDestinations.VETERINARY_NETWORK) { VeterinaryNetworkScreen() }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewProfessionalToolsDashboardScreen() {
+    MaterialTheme {
+        ProfessionalToolsFeatureNavigator()
+    }
+}

--- a/app/src/main/java/com/example/rooster/professionaltools/casestudies/CaseStudyScreen.kt
+++ b/app/src/main/java/com/example/rooster/professionaltools/casestudies/CaseStudyScreen.kt
@@ -1,0 +1,427 @@
+package com.example.rooster.professionaltools.casestudies
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Comment
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import kotlin.random.Random
+
+// --- Data Classes ---
+data class PatientSignalment(
+    val species: String, val breed: String, val age: String, val sex: String, val weightKg: Double?
+)
+
+data class DiagnosticWorkupItem(val test: String, val findings: String)
+data class CaseStudyOutcome(val status: String, val dateResolvedOrClosed: Date, val longTermFollowUp: String?)
+data class CaseStudyAttachment(val type: String, val filename: String, val caption: String)
+data class PeerComment(
+    val commentId: String, val vetId: String, val vetName: String, val commentText: String, val timestamp: Date
+) {
+    fun getFormattedTimestamp(): String = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(timestamp)
+}
+
+data class CaseStudy(
+    val studyId: String,
+    var title: String,
+    val authorVetId: String,
+    val authorVetName: String,
+    val dateCreated: Date,
+    var status: String, // draft, published, peer_review, archived
+    var confidentiality: String,
+    var patientSignalment: PatientSignalment,
+    var dateOfPresentation: Date,
+    var presentingComplaint: String,
+    var history: String,
+    var diagnosticWorkup: List<DiagnosticWorkupItem> = emptyList(),
+    var diagnosis: String,
+    var differentialDiagnoses: List<String> = emptyList(),
+    var treatmentProtocol: String,
+    var treatmentChallenges: String?,
+    var outcome: CaseStudyOutcome,
+    var discussionAndLearningPoints: String,
+    var attachments: List<CaseStudyAttachment> = emptyList(),
+    var keywords: List<String> = emptyList(),
+    var citations: List<String> = emptyList(),
+    var viewCount: Int = 0,
+    var peerComments: MutableList<PeerComment> = mutableListOf()
+) {
+    fun getFormattedDate(date: Date?): String =
+        date?.let { SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(it) } ?: "N/A"
+}
+
+// --- ViewModel ---
+class CaseStudyViewModel : ViewModel() {
+    private val _caseStudies = MutableStateFlow<List<CaseStudy>>(emptyList())
+    val caseStudies: StateFlow<List<CaseStudy>> = _caseStudies
+
+    private val _selectedCaseStudy = MutableStateFlow<CaseStudy?>(null)
+    val selectedCaseStudy: StateFlow<CaseStudy?> = _selectedCaseStudy
+
+    // Mock data for creation dialogs
+    val speciesList = listOf("Cow", "Dog", "Horse", "Cat", "Sheep", "Pig")
+    val mockDiagnoses = listOf("Atypical Pneumonia", "Laminitis", "Mastitis", "GDV", "Colic")
+    val statuses = listOf("draft", "published", "peer_review", "archived")
+    val knownVetNames = mapOf("vet001" to "Dr. Alice", "vet002" to "Dr. Bob", "vet003" to "Dr. Carol")
+
+
+    init {
+        loadMockCaseStudies()
+    }
+
+    private fun loadMockCaseStudies(count: Int = 3) {
+        val tempStudies = mutableListOf<CaseStudy>()
+        for (i in 0 until count) {
+            val species = speciesList.random()
+            val diagnosis = mockDiagnoses.random()
+            val presentationDate = Date(System.currentTimeMillis() - Random.nextLong(30, 365) * 86400000L)
+            val resolvedDate = Date(presentationDate.time + Random.nextLong(7, 90) * 86400000L)
+            val authorId = knownVetNames.keys.random()
+
+            tempStudies.add(
+                CaseStudy(
+                    studyId = "cs_${presentationDate.time}_$i",
+                    title = "Case: $diagnosis in a $species",
+                    authorVetId = authorId,
+                    authorVetName = knownVetNames[authorId] ?: "Unknown Vet",
+                    dateCreated = Date(resolvedDate.time + Random.nextLong(1,10) * 86400000L),
+                    status = statuses.filterNot { it == "archived"}.random(),
+                    confidentiality = listOf("anonymous_patient", "owner_consent_given").random(),
+                    patientSignalment = PatientSignalment(species, "Breed ${Random.nextInt(1,5)}", "${Random.nextInt(1,10)} years", listOf("Male", "Female", "Castrated Male").random(), Random.nextDouble(3.0, 700.0)),
+                    dateOfPresentation = presentationDate,
+                    presentingComplaint = "Presented with severe symptoms.",
+                    history = "Relevant history noted.",
+                    diagnosticWorkup = listOf(DiagnosticWorkupItem("Physical Exam", "Key findings noted.")),
+                    diagnosis = diagnosis,
+                    treatmentProtocol = "Standard protocol followed.",
+                    outcome = CaseStudyOutcome(listOf("Full Recovery", "Partial Recovery", "Managed").random(), resolvedDate, "Follow-up scheduled."),
+                    discussionAndLearningPoints = "Important learning points from this case.",
+                    keywords = listOf(species, diagnosis.split(" ").first()),
+                    viewCount = Random.nextInt(0, 200)
+                )
+            )
+        }
+        _caseStudies.value = tempStudies.sortedByDescending { it.dateCreated }
+    }
+
+    fun selectCaseStudy(studyId: String) {
+        val study = _caseStudies.value.find { it.studyId == studyId }
+        study?.let {
+            it.viewCount++ // Increment view count
+            _selectedCaseStudy.value = it.copy() // Ensure UI update
+            _caseStudies.update { list -> list.map { c -> if(c.studyId == studyId) c.copy(viewCount = c.viewCount) else c } }
+        }
+    }
+
+    fun clearSelectedCaseStudy() {
+        _selectedCaseStudy.value = null
+    }
+
+    fun addComment(studyId: String, vetId: String, commentText: String) {
+        _caseStudies.update { studies ->
+            studies.map { study ->
+                if (study.studyId == studyId && study.status == "published") {
+                    val newComment = PeerComment("cmt_${Date().time}", vetId, knownVetNames[vetId] ?: "Vet User", commentText, Date())
+                    study.copy(peerComments = (study.peerComments + newComment).toMutableList())
+                } else study
+            }
+        }
+        // If this comment was for the selected study, update it too
+        if (_selectedCaseStudy.value?.studyId == studyId && _selectedCaseStudy.value?.status == "published") {
+             val newComment = PeerComment("cmt_${Date().time}", vetId, knownVetNames[vetId] ?: "Vet User", commentText, Date())
+            _selectedCaseStudy.update { it?.copy(peerComments = (it.peerComments + newComment).toMutableList()) }
+        }
+    }
+
+    fun createCaseStudy(title: String, authorVetId: String, signalment: PatientSignalment, diagnosis: String, discussion: String) {
+        val now = Date()
+        val newStudy = CaseStudy(
+            studyId = "cs_new_${now.time}", title = title, authorVetId = authorVetId, authorVetName = knownVetNames[authorVetId] ?: "Vet User",
+            dateCreated = now, status = "draft", confidentiality = "anonymous_patient", patientSignalment = signalment,
+            dateOfPresentation = now, presentingComplaint = "N/A (Simplified)", history = "N/A (Simplified)", diagnosis = diagnosis,
+            treatmentProtocol = "N/A (Simplified)", outcome = CaseStudyOutcome("Pending", now, null), discussionAndLearningPoints = discussion,
+            keywords = listOf(signalment.species, diagnosis.split(" ").firstOrNull() ?: "")
+        )
+        _caseStudies.update { (listOf(newStudy) + it).sortedByDescending { cs -> cs.dateCreated } }
+    }
+}
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CaseStudyScreen(viewModel: CaseStudyViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val studies by viewModel.caseStudies.collectAsState()
+    val selectedStudy by viewModel.selectedCaseStudy.collectAsState()
+
+    var showCreateDialog by remember { mutableStateOf(false) }
+
+    if (showCreateDialog) {
+        CreateCaseStudyDialog(viewModel = viewModel, onDismiss = { showCreateDialog = false })
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(if (selectedStudy == null) "Case Studies" else "Case Study Details") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color(0xFF00897B)), // Dark Teal
+                navigationIcon = if (selectedStudy != null) {
+                    { IconButton(onClick = { viewModel.clearSelectedCaseStudy() }) { Icon(Icons.Filled.ArrowBack, "Back") } }
+                } else null,
+                actions = {
+                    if (selectedStudy == null) { // Search on list view
+                        IconButton(onClick = { /* TODO: Implement Search/Filter Dialog */ }) {
+                            Icon(Icons.Filled.Search, "Search Case Studies")
+                        }
+                    }
+                }
+            )
+        },
+        floatingActionButton = {
+            if (selectedStudy == null) { // FAB on list view
+                FloatingActionButton(onClick = { showCreateDialog = true }) {
+                    Icon(Icons.Filled.Add, "Create New Case Study")
+                }
+            }
+        }
+    ) { paddingValues ->
+        if (selectedStudy == null) {
+            CaseStudyListScreen(paddingValues, studies, onStudyClick = { viewModel.selectCaseStudy(it.studyId) })
+        } else {
+            CaseStudyDetailScreen(paddingValues, selectedStudy!!, viewModel)
+        }
+    }
+}
+
+@Composable
+fun CaseStudyListScreen(paddingValues: PaddingValues, studies: List<CaseStudy>, onStudyClick: (CaseStudy) -> Unit) {
+    LazyColumn(modifier = Modifier.padding(paddingValues).padding(16.dp)) {
+        if (studies.isEmpty()) {
+            item { Text("No case studies found.") }
+        } else {
+            items(studies, key = { it.studyId }) { study ->
+                CaseStudyListItem(study, onClick = { onStudyClick(study) })
+            }
+        }
+    }
+}
+
+@Composable
+fun CaseStudyListItem(study: CaseStudy, onClick: () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp).clickable(onClick = onClick), elevation = CardDefaults.cardElevation(2.dp)) {
+        Column(Modifier.padding(12.dp)) {
+            Text(study.title, style = MaterialTheme.typography.titleMedium)
+            Text("Author: ${study.authorVetName}, Species: ${study.patientSignalment.species}", style = MaterialTheme.typography.bodyMedium)
+            Text("Diagnosis: ${study.diagnosis}", style = MaterialTheme.typography.bodyMedium)
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text("Status: ${study.status}", style = MaterialTheme.typography.bodySmall)
+                Text("Views: ${study.viewCount}", style = MaterialTheme.typography.bodySmall)
+            }
+        }
+    }
+}
+
+@Composable
+fun CaseStudyDetailScreen(paddingValues: PaddingValues, study: CaseStudy, viewModel: CaseStudyViewModel) {
+    var commentText by remember { mutableStateOf("") }
+
+    LazyColumn(modifier = Modifier.padding(paddingValues).padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        item { Text(study.title, style = MaterialTheme.typography.headlineMedium) }
+        item { DetailSection("Author", "${study.authorVetName} (${study.authorVetId})") }
+        item { DetailSection("Published", study.getFormattedDate(study.dateCreated) + " (Status: ${study.status})") }
+        item { DetailSection("Confidentiality", study.confidentiality) }
+
+        item { SectionTitle("Patient Signalment") }
+        item { Text("Species: ${study.patientSignalment.species}, Breed: ${study.patientSignalment.breed}") }
+        item { Text("Age: ${study.patientSignalment.age}, Sex: ${study.patientSignalment.sex}, Weight: ${study.patientSignalment.weightKg?.toString() ?: "N/A"} kg") }
+
+        item { SectionTitle("Case Details") }
+        item { DetailSection("Presentation Date", study.getFormattedDate(study.dateOfPresentation)) }
+        item { DetailSection("Complaint", study.presentingComplaint) }
+        item { DetailSection("History", study.history) }
+
+        if (study.diagnosticWorkup.isNotEmpty()) {
+            item { SectionTitle("Diagnostic Workup") }
+            items(study.diagnosticWorkup) { workup -> Text("- ${workup.test}: ${workup.findings}") }
+        }
+
+        item { DetailSection("Diagnosis", study.diagnosis, isBoldValue = true) }
+        if (study.differentialDiagnoses.isNotEmpty()) {
+            item { DetailSection("Differential Diagnoses", study.differentialDiagnoses.joinToString()) }
+        }
+        item { DetailSection("Treatment Protocol", study.treatmentProtocol) }
+        study.treatmentChallenges?.let { item { DetailSection("Treatment Challenges", it) } }
+
+        item { SectionTitle("Outcome") }
+        item { Text("Status: ${study.outcome.status}, Resolved/Closed: ${study.getFormattedDate(study.outcome.dateResolvedOrClosed)}") }
+        study.outcome.longTermFollowUp?.let { item { Text("Follow-up: $it") } }
+
+        item { DetailSection("Discussion & Learning Points", study.discussionAndLearningPoints) }
+
+        if (study.keywords.isNotEmpty()) item { DetailSection("Keywords", study.keywords.joinToString()) }
+        // Attachments, Citations could be listed similarly
+
+        item { SectionTitle("Comments (${study.peerComments.size})") }
+        if (study.peerComments.isEmpty()) {
+            item { Text("No comments yet.") }
+        } else {
+            items(study.peerComments, key = {it.commentId}) { comment -> CommentItem(comment) }
+        }
+
+        if (study.status == "published") { // Allow comments only on published
+            item {
+                OutlinedTextField(
+                    value = commentText,
+                    onValueChange = { commentText = it },
+                    label = { Text("Add a comment") },
+                    modifier = Modifier.fillMaxWidth().padding(top = 8.dp)
+                )
+                Button(
+                    onClick = {
+                        if (commentText.isNotBlank()) {
+                            viewModel.addComment(study.studyId, "vet_currentUser", commentText) // Use actual current vet ID
+                            commentText = ""
+                        }
+                    },
+                    modifier = Modifier.align(Alignment.End).padding(top = 8.dp),
+                    enabled = commentText.isNotBlank()
+                ) { Icon(Icons.Filled.Comment, "Post"); Spacer(Modifier.width(4.dp)); Text("Post Comment") }
+            }
+        }
+    }
+}
+
+@Composable
+fun DetailSection(label: String, value: String, isBoldValue: Boolean = false) {
+    Column(modifier = Modifier.padding(bottom = 4.dp)) {
+        Text(label, style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.Bold)
+        Text(value, style = MaterialTheme.typography.bodyLarge, fontWeight = if(isBoldValue) FontWeight.Bold else FontWeight.Normal)
+    }
+}
+@Composable
+fun SectionTitle(title: String) = Text(title, style = MaterialTheme.typography.titleMedium, modifier = Modifier.padding(top = 12.dp, bottom = 4.dp))
+
+@Composable
+fun CommentItem(comment: PeerComment) {
+    Column(Modifier.padding(vertical = 4.dp, horizontal = 8.dp)) {
+        Text("${comment.vetName} (${comment.getFormattedTimestamp()})", style = MaterialTheme.typography.labelMedium)
+        Text(comment.commentText, style = MaterialTheme.typography.bodyMedium)
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CreateCaseStudyDialog(viewModel: CaseStudyViewModel, onDismiss: () -> Unit) {
+    var title by remember { mutableStateOf("") }
+    var species by remember { mutableStateOf(viewModel.speciesList.first()) }
+    var diagnosis by remember { mutableStateOf(viewModel.mockDiagnoses.first()) }
+    var discussion by remember { mutableStateOf("") }
+    // Simplified signalment for dialog
+    var patientAge by remember { mutableStateOf("") }
+    var patientSex by remember { mutableStateOf("") }
+
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Create New Case Study") },
+        text = {
+            LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                item { OutlinedTextField(value = title, onValueChange = { title = it }, label = { Text("Title") }) }
+                item { ExposedDropdownMenuForOptions("Species", viewModel.speciesList, species) { species = it } }
+                item { OutlinedTextField(value = patientAge, onValueChange = { patientAge = it }, label = { Text("Patient Age (e.g., 5 years)") }) }
+                item { OutlinedTextField(value = patientSex, onValueChange = { patientSex = it }, label = { Text("Patient Sex") }) }
+                item { ExposedDropdownMenuForOptions("Primary Diagnosis", viewModel.mockDiagnoses, diagnosis) { diagnosis = it } }
+                item { OutlinedTextField(value = discussion, onValueChange = { discussion = it }, label = { Text("Discussion & Learning Points") }, minLines = 3) }
+            }
+        },
+        confirmButton = {
+            Button(onClick = {
+                if (title.isNotBlank() && diagnosis.isNotBlank() && discussion.isNotBlank()) {
+                    val signalment = PatientSignalment(species, "Mixed (Dialog)", patientAge, patientSex, null)
+                    viewModel.createCaseStudy(title, "vet_currentUser", signalment, diagnosis, discussion)
+                    onDismiss()
+                }
+            }, enabled = title.isNotBlank() && diagnosis.isNotBlank() && discussion.isNotBlank()) { Text("Create Draft") }
+        },
+        dismissButton = { Button(onClick = onDismiss) { Text("Cancel") } }
+    )
+}
+
+
+// Re-using ExposedDropdownMenuForOptions, assuming it's accessible
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ExposedDropdownMenuForOptions( // Copied for standalone preview if needed
+    label: String,
+    options: List<String>,
+    selectedOption: String,
+    onOptionSelected: (String) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = !expanded }
+    ) {
+        OutlinedTextField(
+            value = selectedOption,
+            onValueChange = {}, readOnly = true,
+            label = { Text(label) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier.menuAnchor().fillMaxWidth()
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            options.forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(option) },
+                    onClick = {
+                        onOptionSelected(option)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, heightDp = 1000)
+@Composable
+fun PreviewCaseStudyScreen_List() {
+    MaterialTheme {
+        CaseStudyScreen(viewModel = CaseStudyViewModel())
+    }
+}
+
+@Preview(showBackground = true, heightDp = 1000)
+@Composable
+fun PreviewCaseStudyScreen_Detail() {
+    val viewModel = CaseStudyViewModel()
+    // Simulate selecting a study for detail view preview
+    LaunchedEffect(Unit) {
+        if(viewModel.caseStudies.value.isNotEmpty()){
+            viewModel.selectCaseStudy(viewModel.caseStudies.value.first().studyId)
+        }
+    }
+    MaterialTheme {
+        CaseStudyScreen(viewModel = viewModel)
+    }
+}

--- a/app/src/main/java/com/example/rooster/professionaltools/diagnosisassistant/DiagnosisAssistantScreen.kt
+++ b/app/src/main/java/com/example/rooster/professionaltools/diagnosisassistant/DiagnosisAssistantScreen.kt
@@ -1,0 +1,292 @@
+package com.example.rooster.professionaltools.diagnosisassistant
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+
+// --- Data Classes ---
+data class PotentialCondition(
+    val condition: String,
+    val confidence: Double,
+    val urgency: String,
+    val nextSteps: String,
+    val matchedSymptoms: List<String>
+)
+
+data class DiagnosticSessionResult(
+    val sessionId: String,
+    val species: String,
+    val primarySymptoms: List<String>,
+    val potentialConditions: List<PotentialCondition>,
+    val timestamp: Long,
+    val error: String? = null
+)
+
+data class ConditionDetails(
+    val name: String,
+    val information: String
+)
+
+// --- ViewModel ---
+class DiagnosisAssistantViewModel : ViewModel() {
+    private val _sessionResult = MutableStateFlow<DiagnosticSessionResult?>(null)
+    val sessionResult: StateFlow<DiagnosticSessionResult?> = _sessionResult
+
+    private val _conditionDetails = MutableStateFlow<ConditionDetails?>(null)
+    val conditionDetails: StateFlow<ConditionDetails?> = _conditionDetails
+
+    // Simplified Knowledge Base (mirrors Python structure)
+    private val knowledgeBase: Map<String, Map<String, Any>> = mapOf(
+        "Cow" to mapOf(
+            "symptoms" to mapOf(
+                "coughing" to listOf(
+                    mapOf("condition" to "Respiratory Infection (BRD Complex)", "confidence" to 0.7, "urgency" to "High", "next_steps" to "Isolate, check temp, consult vet for antibiotics/anti-inflammatory. Good ventilation."),
+                    mapOf("condition" to "Lungworm", "confidence" to 0.4, "urgency" to "Medium", "next_steps" to "Fecal test, consult vet for dewormer. Pasture hygiene.")
+                ),
+                "lameness" to listOf(
+                    mapOf("condition" to "Foot Rot", "confidence" to 0.6, "urgency" to "Medium", "next_steps" to "Clean foot, topical treatment, dry footing. Consult vet if severe."),
+                    mapOf("condition" to "Injury (Sprain/Fracture)", "confidence" to 0.3, "urgency" to "High", "next_steps" to "Immobilize, consult vet immediately.")
+                )
+            ),
+            "common_conditions_info" to mapOf(
+                "Respiratory Infection (BRD Complex)" to "Common in stressed/young cattle. Bacterial/viral. Signs: cough, fever, nasal discharge.",
+                "Foot Rot" to "Bacterial infection of the foot, causes severe lameness."
+            )
+        ),
+        "Dog" to mapOf(
+            "symptoms" to mapOf(
+                "vomiting" to listOf(
+                    mapOf("condition" to "Dietary Indiscretion", "confidence" to 0.7, "urgency" to "Low-Medium", "next_steps" to "Withhold food 12-24h, then bland diet. Vet if persistent."),
+                    mapOf("condition" to "Gastroenteritis", "confidence" to 0.5, "urgency" to "Medium", "next_steps" to "Consult vet for supportive care."),
+                    mapOf("condition" to "Foreign Body Obstruction", "confidence" to 0.3, "urgency" to "Critical", "next_steps" to "IMMEDIATE vet attention if suspected.")
+                ),
+                "itching_scratching" to listOf(
+                    mapOf("condition" to "Flea Allergy Dermatitis (FAD)", "confidence" to 0.7, "urgency" to "Medium", "next_steps" to "Strict flea control. Consult vet for relief."),
+                    mapOf("condition" to "Atopic Dermatitis", "confidence" to 0.6, "urgency" to "Medium", "next_steps" to "Consult vet for diagnosis and management plan.")
+                )
+            ),
+            "common_conditions_info" to mapOf(
+                "Dietary Indiscretion" to "Caused by eating inappropriate items. Usually self-limiting.",
+                "Flea Allergy Dermatitis (FAD)" to "Allergic reaction to flea saliva. Intense itching."
+            )
+        )
+    )
+
+    val availableSpecies: List<String> = knowledgeBase.keys.toList()
+    val availableSymptomsBySpecies: Map<String, List<String>> = knowledgeBase.mapValues { entry ->
+        ((entry.value["symptoms"] as? Map<String, List<Any>>)?.keys?.toList() ?: emptyList())
+    }
+
+
+    @Suppress("UNCHECKED_CAST")
+    fun startDiagnosticSession(species: String, symptoms: List<String>) {
+        val speciesKb = knowledgeBase[species]
+        if (speciesKb == null) {
+            _sessionResult.value = DiagnosticSessionResult("error_${System.currentTimeMillis()}", species, symptoms, emptyList(), System.currentTimeMillis(), "Knowledge base for $species not available.")
+            return
+        }
+
+        val symptomMap = speciesKb["symptoms"] as? Map<String, List<Map<String, Any>>> ?: emptyMap()
+        val possibleMatches = mutableListOf<PotentialCondition>()
+
+        symptoms.forEach { symptomKey ->
+            symptomMap[symptomKey]?.forEach { conditionInfo ->
+                val conditionName = conditionInfo["condition"] as String
+                val existingMatchIndex = possibleMatches.indexOfFirst { it.condition == conditionName }
+
+                if (existingMatchIndex != -1) {
+                    val existing = possibleMatches[existingMatchIndex]
+                    possibleMatches[existingMatchIndex] = existing.copy(
+                        confidence = minOf(1.0, existing.confidence + 0.1 * (conditionInfo["confidence"] as Double)),
+                        matchedSymptoms = (existing.matchedSymptoms + symptomKey).distinct()
+                    )
+                } else {
+                    possibleMatches.add(
+                        PotentialCondition(
+                            condition = conditionName,
+                            confidence = conditionInfo["confidence"] as Double,
+                            urgency = conditionInfo["urgency"] as String,
+                            nextSteps = conditionInfo["next_steps"] as String,
+                            matchedSymptoms = listOf(symptomKey)
+                        )
+                    )
+                }
+            }
+        }
+        possibleMatches.sortByDescending { it.confidence }
+        _sessionResult.value = DiagnosticSessionResult("diag_${System.currentTimeMillis()}", species, symptoms, possibleMatches, System.currentTimeMillis())
+        _conditionDetails.value = null // Clear previous details
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    fun getConditionDetails(species: String, conditionName: String) {
+        val info = (knowledgeBase[species]?.get("common_conditions_info") as? Map<String, String>)?.get(conditionName)
+        _conditionDetails.value = ConditionDetails(conditionName, info ?: "No detailed information available.")
+    }
+
+    fun clearSession() {
+        _sessionResult.value = null
+        _conditionDetails.value = null
+    }
+}
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun DiagnosisAssistantScreen(viewModel: DiagnosisAssistantViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val sessionResult by viewModel.sessionResult.collectAsState()
+    val conditionDetails by viewModel.conditionDetails.collectAsState()
+
+    var selectedSpecies by remember { mutableStateOf(viewModel.availableSpecies.firstOrNull() ?: "") }
+    var symptomsInput by remember { mutableStateOf("") } // Comma-separated
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text("Diagnosis Assistant") }, colors = TopAppBarDefaults.topAppBarColors(containerColor = Color(0xFF5C6BC0))) // Indigo
+        }
+    ) { paddingValues ->
+        Column(modifier = Modifier.padding(paddingValues).padding(16.dp).fillMaxSize()) {
+            Text("Disclaimer: This is a mock assistant and NOT a substitute for professional veterinary diagnosis.", style = MaterialTheme.typography.bodySmall, color = Color.Gray)
+            Spacer(Modifier.height(8.dp))
+
+            // Inputs
+            ExposedDropdownMenuBoxForOptions("Select Species", viewModel.availableSpecies, selectedSpecies) { selectedSpecies = it }
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = symptomsInput,
+                onValueChange = { symptomsInput = it },
+                label = { Text("Enter Symptoms (comma-separated)") },
+                modifier = Modifier.fillMaxWidth(),
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                keyboardActions = KeyboardActions(onSearch = {
+                    val symptomsList = symptomsInput.split(",").map { it.trim() }.filter { it.isNotBlank() }
+                    if (selectedSpecies.isNotBlank() && symptomsList.isNotEmpty()) {
+                        viewModel.startDiagnosticSession(selectedSpecies, symptomsList)
+                    }
+                    keyboardController?.hide()
+                })
+            )
+            Spacer(Modifier.height(8.dp))
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                 Button(onClick = {
+                    val symptomsList = symptomsInput.split(",").map { it.trim() }.filter { it.isNotBlank() }
+                    if (selectedSpecies.isNotBlank() && symptomsList.isNotEmpty()) {
+                        viewModel.startDiagnosticSession(selectedSpecies, symptomsList)
+                    }
+                    keyboardController?.hide()
+                }) { Icon(Icons.Filled.Search, "Diagnose"); Spacer(Modifier.width(4.dp)); Text("Get Diagnosis") }
+                Button(onClick = { viewModel.clearSession(); symptomsInput = "" }, colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.secondary)) { Text("Clear") }
+            }
+
+
+            Spacer(Modifier.height(16.dp))
+
+            // Results
+            sessionResult?.let { result ->
+                if (result.error != null) {
+                    Text("Error: ${result.error}", color = MaterialTheme.colorScheme.error)
+                } else {
+                    Text("Results for ${result.species} with symptoms: ${result.primarySymptoms.joinToString()}", style = MaterialTheme.typography.titleMedium)
+                    if (result.potentialConditions.isEmpty()) {
+                        Text("No potential conditions found for the given symptoms.")
+                    } else {
+                        LazyColumn(modifier = Modifier.weight(1f)) {
+                            items(result.potentialConditions) { pc ->
+                                PotentialConditionCard(pc) {
+                                    viewModel.getConditionDetails(result.species, pc.condition)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            conditionDetails?.let { details ->
+                ConditionDetailsDialog(details = details, onDismiss = { viewModel._conditionDetails.value = null /* Hacky way to clear for now */ })
+            }
+        }
+    }
+}
+
+@Composable
+fun PotentialConditionCard(pc: PotentialCondition, onViewDetails: () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp).clickable(onClick = onViewDetails), elevation = CardDefaults.cardElevation(2.dp)) {
+        Column(Modifier.padding(12.dp)) {
+            Text("${pc.condition} (Confidence: %.2f)".format(pc.confidence), style = MaterialTheme.typography.titleMedium)
+            Text("Urgency: ${pc.urgency}", color = when(pc.urgency){ "High" -> Color.Red; "Critical" -> Color.Red; "Medium" -> Color(0xFFFFA000); else -> Color.Green })
+            Text("Matched Symptoms: ${pc.matchedSymptoms.joinToString()}", style = MaterialTheme.typography.bodySmall)
+            Spacer(Modifier.height(4.dp))
+            Text("Next Steps: ${pc.nextSteps}", style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+}
+
+@Composable
+fun ConditionDetailsDialog(details: ConditionDetails, onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(details.name) },
+        text = { Text(details.information) },
+        confirmButton = { Button(onClick = onDismiss) { Text("Close") } }
+    )
+}
+
+// Re-using ExposedDropdownMenuForOptions
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ExposedDropdownMenuForOptions(
+    label: String, options: List<String>, selectedOption: String, onOptionSelected: (String) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = !expanded }) {
+        OutlinedTextField(
+            value = selectedOption, onValueChange = {}, readOnly = true, label = { Text(label) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier.menuAnchor().fillMaxWidth()
+        )
+        ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            options.forEach { option ->
+                DropdownMenuItem(text = { Text(option) }, onClick = { onOptionSelected(option); expanded = false })
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, heightDp = 800)
+@Composable
+fun PreviewDiagnosisAssistantScreen() {
+    MaterialTheme {
+        DiagnosisAssistantScreen(viewModel = DiagnosisAssistantViewModel())
+    }
+}
+
+@Preview(showBackground = true, heightDp = 800)
+@Composable
+fun PreviewDiagnosisAssistantScreen_WithResults() {
+    val viewModel = DiagnosisAssistantViewModel()
+    // Simulate a session for preview
+    LaunchedEffect(Unit) {
+        viewModel.startDiagnosticSession("Dog", listOf("vomiting", "lethargy"))
+    }
+    MaterialTheme {
+        DiagnosisAssistantScreen(viewModel = viewModel)
+    }
+}

--- a/app/src/main/java/com/example/rooster/professionaltools/educationalcontent/EducationalContentScreen.kt
+++ b/app/src/main/java/com/example/rooster/professionaltools/educationalcontent/EducationalContentScreen.kt
@@ -1,0 +1,377 @@
+package com.example.rooster.professionaltools.educationalcontent
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.update
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import kotlin.random.Random
+
+// --- Data Classes ---
+data class EducationalContentItem(
+    val contentId: String,
+    val title: String,
+    val contentType: String, // Article, Video, FAQ, Guide, Webinar Recording
+    val speciesCategory: String,
+    val topicCategory: String,
+    val author: String,
+    val publishDate: Date,
+    var lastUpdatedDate: Date,
+    val bodyOrUrl: String, // Full text for Article/FAQ, URL for Video/Guide/Webinar
+    val keywords: List<String>,
+    val accessLevel: String, // public, registered_users, vets_only
+    var viewCount: Int = 0,
+    val uploadedBy: String? = null
+) {
+    fun getFormattedDate(date: Date?): String =
+        date?.let { SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(it) } ?: "N/A"
+}
+
+data class ContentFilters(
+    val query: String? = null,
+    val species: String? = null,
+    val topic: String? = null,
+    val type: String? = null
+)
+
+// --- ViewModel ---
+class EducationalContentViewModel : ViewModel() {
+    private val _allContent = MutableStateFlow<List<EducationalContentItem>>(emptyList())
+    private val _filters = MutableStateFlow(ContentFilters())
+    val filters: StateFlow<ContentFilters> = _filters
+
+    val filteredContent: StateFlow<List<EducationalContentItem>> = combine(_allContent, _filters) { content, filters ->
+        content.filter { item ->
+            val userAccessLevel = currentSimulatedUserType.value // Use simulated user type for access control
+            val itemAccess = item.accessLevel
+            val accessible = when (itemAccess) {
+                "public" -> true
+                "registered_users" -> userAccessLevel != "guest"
+                "vets_only" -> userAccessLevel == "vet"
+                else -> true // Default to accessible if unknown
+            }
+
+            accessible &&
+            (filters.query.isNullOrBlank() || item.title.contains(filters.query, ignoreCase = true) || item.keywords.any{ it.contains(filters.query, ignoreCase = true)}) &&
+            (filters.species.isNullOrBlank() || item.speciesCategory.equals(filters.species, ignoreCase = true)) &&
+            (filters.topic.isNullOrBlank() || item.topicCategory.equals(filters.topic, ignoreCase = true)) &&
+            (filters.type.isNullOrBlank() || item.contentType.equals(filters.type, ignoreCase = true))
+        }.sortedByDescending { it.publishDate }
+    }.stateIn(kotlinx.coroutines.MainScope(), kotlinx.coroutines.flow.SharingStarted.WhileSubscribed(5000), emptyList())
+
+    private val _selectedContent = MutableStateFlow<EducationalContentItem?>(null)
+    val selectedContent: StateFlow<EducationalContentItem?> = _selectedContent
+
+    // Mock data for UI elements
+    val speciesCategories = listOf("Any", "General", "Cattle", "Poultry", "Swine", "Horses", "Companion Animals")
+    val topicCategories = listOf("Any", "Nutrition", "Disease Prevention", "Common Diseases", "Farm Management", "Biosecurity")
+    val contentTypes = listOf("Any", "Article", "Video", "FAQ", "Guide")
+    val accessLevels = listOf("public", "registered_users", "vets_only")
+    val authors = listOf("Dr. Vet Expert", "AgriConsult Inc.", "University Extension")
+
+    // Simulate current user type for access control demo
+    val currentSimulatedUserType = MutableStateFlow("vet") // "guest", "farmer", "vet"
+
+
+    init {
+        loadMockContent()
+    }
+
+    private fun loadMockContent(count: Int = 10) {
+        val tempContent = mutableListOf<EducationalContentItem>()
+        for (i in 0 until count) {
+            val type = contentTypes.filterNot { it == "Any" }.random()
+            val species = speciesCategories.filterNot { it == "Any" }.random()
+            val topic = topicCategories.filterNot { it == "Any" }.random()
+            val body = if (type == "Article" || type == "FAQ") "This is the main body for '$type' about $topic in $species. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat." else "https://example.com/content/${type.lowercase()}/$i"
+            tempContent.add(
+                EducationalContentItem(
+                    contentId = "edu_${System.currentTimeMillis()}_$i",
+                    title = "${if(type == "FAQ") "Q&A" else "Guide to"} $topic for $species",
+                    contentType = type, speciesCategory = species, topicCategory = topic,
+                    author = authors.random(),
+                    publishDate = Date(System.currentTimeMillis() - Random.nextLong(1, 365) * 86400000L),
+                    lastUpdatedDate = Date(System.currentTimeMillis() - Random.nextLong(0, 30) * 86400000L),
+                    bodyOrUrl = body,
+                    keywords = listOf(species, topic, type),
+                    accessLevel = accessLevels.random(),
+                    uploadedBy = "admin_system"
+                )
+            )
+        }
+        _allContent.value = tempContent
+    }
+
+    fun updateFilters(newFilters: ContentFilters) {
+        _filters.value = newFilters
+    }
+
+    fun selectContent(contentId: String) {
+        _selectedContent.value = _allContent.value.find { it.contentId == contentId }?.also {
+            it.viewCount++ // This won't trigger recomposition of the list item directly, fine for this mock.
+             _allContent.update { list -> list.map { c -> if(c.contentId == contentId) c.copy(viewCount = c.viewCount) else c } }
+        }
+    }
+    fun clearSelectedContent() {
+        _selectedContent.value = null
+    }
+
+    fun addContent(title: String, type: String, species: String, topic: String, author: String, body: String, keywords: List<String>, access: String, uploader: String) {
+        val newItem = EducationalContentItem(
+            contentId = "edu_new_${System.currentTimeMillis()}", title = title, contentType = type, speciesCategory = species, topicCategory = topic,
+            author = author, publishDate = Date(), lastUpdatedDate = Date(), bodyOrUrl = body, keywords = keywords, accessLevel = access, uploadedBy = uploader
+        )
+        _allContent.update { (listOf(newItem) + it) }
+    }
+}
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EducationalContentScreen(viewModel: EducationalContentViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val contentList by viewModel.filteredContent.collectAsState()
+    val selectedContent by viewModel.selectedContent.collectAsState()
+    val currentFilters by viewModel.filters.collectAsState()
+    val currentUserType by viewModel.currentSimulatedUserType.collectAsState()
+
+
+    var showFilterDialog by remember { mutableStateOf(false) }
+    var showAddContentDialog by remember { mutableStateOf(false) }
+
+    if (showFilterDialog) {
+        FilterContentDialog(currentFilters, viewModel, onDismiss = { showFilterDialog = false })
+    }
+    if (showAddContentDialog) {
+        AddContentDialog(viewModel, onDismiss = { showAddContentDialog = false })
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(if (selectedContent == null) "Educational Content" else selectedContent!!.title) },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color(0xFF3F51B5)), // Indigo
+                navigationIcon = if (selectedContent != null) {
+                    { IconButton(onClick = { viewModel.clearSelectedContent() }) { Icon(Icons.Filled.ArrowBack, "Back") } }
+                } else null,
+                actions = {
+                    if (selectedContent == null) { // Actions for list view
+                        IconButton(onClick = { showFilterDialog = true }) { Icon(Icons.Filled.Search, "Filter Content") }
+                    }
+                }
+            )
+        },
+        floatingActionButton = {
+            if (selectedContent == null && currentUserType == "vet") { // Allow vets to add content
+                FloatingActionButton(onClick = { showAddContentDialog = true }) {
+                    Icon(Icons.Filled.Add, "Add New Content")
+                }
+            }
+        }
+    ) { paddingValues ->
+        Column(modifier = Modifier.padding(paddingValues).padding(horizontal = 16.dp)) {
+            // User type switcher for demo purposes
+            if (selectedContent == null) { // Show only on list view
+                Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(vertical = 8.dp)) {
+                    Text("Simulate User: ", style = MaterialTheme.typography.labelMedium)
+                    viewModel.accessLevels.forEach { type -> // Using accessLevels as user types for demo
+                        Button(
+                            onClick = { viewModel.currentSimulatedUserType.value = type },
+                            modifier = Modifier.padding(horizontal = 4.dp),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = if (currentUserType == type) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant
+                            )
+                        ) { Text(type.replaceFirstChar { it.titlecase() }) }
+                    }
+                }
+                Divider()
+            }
+
+            if (selectedContent == null) {
+                EducationalContentList(contentList, onContentClick = { viewModel.selectContent(it.contentId) })
+            } else {
+                EducationalContentDetail(selectedContent!!)
+            }
+        }
+    }
+}
+
+@Composable
+fun EducationalContentList(list: List<EducationalContentItem>, onContentClick: (EducationalContentItem) -> Unit) {
+    if (list.isEmpty()) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text("No content matches your criteria or access level.")
+        }
+        return
+    }
+    LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp), contentPadding = PaddingValues(vertical = 8.dp)) {
+        items(list, key = { it.contentId }) { item ->
+            ContentListItem(item, onClick = { onContentClick(item) })
+        }
+    }
+}
+
+@Composable
+fun ContentListItem(item: EducationalContentItem, onClick: () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth().clickable(onClick = onClick), elevation = CardDefaults.cardElevation(2.dp)) {
+        Column(Modifier.padding(12.dp)) {
+            Text(item.title, style = MaterialTheme.typography.titleMedium)
+            Text("Type: ${item.contentType}, Topic: ${item.topicCategory}, Species: ${item.speciesCategory}", style = MaterialTheme.typography.bodySmall)
+            Text("Author: ${item.author}, Published: ${item.getFormattedDate(item.publishDate)}", style = MaterialTheme.typography.bodySmall)
+            Text("Views: ${item.viewCount}", style = MaterialTheme.typography.bodySmall)
+        }
+    }
+}
+
+@Composable
+fun EducationalContentDetail(content: EducationalContentItem) {
+    val scrollState = rememberScrollState()
+    val uriHandler = LocalUriHandler.current
+
+    Column(Modifier.fillMaxSize().verticalScroll(scrollState).padding(vertical = 8.dp)) {
+        Text(content.title, style = MaterialTheme.typography.headlineMedium)
+        Spacer(Modifier.height(8.dp))
+        Text("Author: ${content.author}", style = MaterialTheme.typography.titleSmall)
+        Text("Published: ${content.getFormattedDate(content.publishDate)} | Updated: ${content.getFormattedDate(content.lastUpdatedDate)}", style = MaterialTheme.typography.bodySmall)
+        Text("Type: ${content.contentType} | Topic: ${content.topicCategory} | Species: ${content.speciesCategory}", style = MaterialTheme.typography.bodySmall)
+        Text("Keywords: ${content.keywords.joinToString()}", style = MaterialTheme.typography.bodySmall)
+        Text("Access: ${content.accessLevel}", style = MaterialTheme.typography.bodySmall)
+        Text("Views: ${content.viewCount}", style = MaterialTheme.typography.bodySmall)
+        Divider(modifier = Modifier.padding(vertical = 12.dp))
+
+        if (content.contentType == "Article" || content.contentType == "FAQ") {
+            Text(content.bodyOrUrl, style = MaterialTheme.typography.bodyLarge)
+        } else { // Video, Guide, Webinar
+            Text("Content URL (click to open if valid):", style = MaterialTheme.typography.labelLarge)
+            TextButton(onClick = { try { uriHandler.openUri(content.bodyOrUrl) } catch (e: Exception) { /* Handle error */ }}) {
+                Text(content.bodyOrUrl, style = MaterialTheme.typography.bodyLarge, color = MaterialTheme.colorScheme.primary)
+            }
+        }
+    }
+}
+
+@Composable
+fun FilterContentDialog(currentFilters: ContentFilters, viewModel: EducationalContentViewModel, onDismiss: () -> Unit) {
+    var query by remember { mutableStateOf(currentFilters.query ?: "") }
+    var species by remember { mutableStateOf(currentFilters.species ?: viewModel.speciesCategories.first()) }
+    var topic by remember { mutableStateOf(currentFilters.topic ?: viewModel.topicCategories.first()) }
+    var type by remember { mutableStateOf(currentFilters.type ?: viewModel.contentTypes.first()) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Filter Content") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(value = query, onValueChange = { query = it }, label = { Text("Search Query") })
+                ExposedDropdownMenuForOptions("Species Category", viewModel.speciesCategories, species) { species = it }
+                ExposedDropdownMenuForOptions("Topic Category", viewModel.topicCategories, topic) { topic = it }
+                ExposedDropdownMenuForOptions("Content Type", viewModel.contentTypes, type) { type = it }
+            }
+        },
+        confirmButton = {
+            Button(onClick = {
+                viewModel.updateFilters(ContentFilters(
+                    query = query.ifBlank { null },
+                    species = if (species == "Any") null else species,
+                    topic = if (topic == "Any") null else topic,
+                    type = if (type == "Any") null else type
+                ))
+                onDismiss()
+            }) { Text("Apply Filters") }
+        },
+        dismissButton = { Button(onClick = onDismiss) { Text("Cancel") } }
+    )
+}
+
+@Composable
+fun AddContentDialog(viewModel: EducationalContentViewModel, onDismiss: () -> Unit) {
+    var title by remember { mutableStateOf("") }
+    var type by remember { mutableStateOf(viewModel.contentTypes.filterNot { it == "Any" }.first()) }
+    var species by remember { mutableStateOf(viewModel.speciesCategories.filterNot { it == "Any" }.first()) }
+    var topic by remember { mutableStateOf(viewModel.topicCategories.filterNot { it == "Any" }.first()) }
+    var author by remember { mutableStateOf(viewModel.authors.first()) }
+    var bodyOrUrl by remember { mutableStateOf("") }
+    var keywords by remember { mutableStateOf("") } // comma-separated
+    var access by remember { mutableStateOf(viewModel.accessLevels.first()) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Add New Educational Content") },
+        text = {
+            LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                item { OutlinedTextField(value = title, onValueChange = {title=it}, label = {Text("Title")}) }
+                item { ExposedDropdownMenuForOptions("Content Type", viewModel.contentTypes.filterNot{it=="Any"}, type) {type=it} }
+                item { ExposedDropdownMenuForOptions("Species", viewModel.speciesCategories.filterNot{it=="Any"}, species) {species=it} }
+                item { ExposedDropdownMenuForOptions("Topic", viewModel.topicCategories.filterNot{it=="Any"}, topic) {topic=it} }
+                item { ExposedDropdownMenuForOptions("Author", viewModel.authors, author) {author=it} }
+                item { OutlinedTextField(value = bodyOrUrl, onValueChange = {bodyOrUrl=it}, label = {Text("Body (for Article/FAQ) or URL")}, minLines = 3) }
+                item { OutlinedTextField(value = keywords, onValueChange = {keywords=it}, label = {Text("Keywords (comma-separated)")}) }
+                item { ExposedDropdownMenuForOptions("Access Level", viewModel.accessLevels, access) {access=it} }
+            }
+        },
+        confirmButton = { Button(onClick = {
+            if(title.isNotBlank() && bodyOrUrl.isNotBlank()){
+                viewModel.addContent(title,type,species,topic,author,bodyOrUrl,keywords.split(",").map(String::trim).filter(String::isNotBlank),access,"vet_currentUser")
+                onDismiss()
+            }
+        }, enabled = title.isNotBlank() && bodyOrUrl.isNotBlank()) {Text("Add Content")} },
+        dismissButton = { Button(onClick = onDismiss) {Text("Cancel")} }
+    )
+}
+
+// Re-using ExposedDropdownMenuForOptions
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ExposedDropdownMenuForOptions(
+    label: String, options: List<String>, selectedOption: String, onOptionSelected: (String) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = !expanded }) {
+        OutlinedTextField(
+            value = selectedOption, onValueChange = {}, readOnly = true, label = { Text(label) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier.menuAnchor().fillMaxWidth()
+        )
+        ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            options.forEach { option -> DropdownMenuItem(text = { Text(option) }, onClick = { onOptionSelected(option); expanded = false }) }
+        }
+    }
+}
+
+@Preview(showBackground = true, heightDp = 700)
+@Composable
+fun PreviewEducationalContentScreen_List() {
+    MaterialTheme { EducationalContentScreen(viewModel = EducationalContentViewModel()) }
+}
+
+@Preview(showBackground = true, heightDp = 700)
+@Composable
+fun PreviewEducationalContentScreen_Detail() {
+    val viewModel = EducationalContentViewModel()
+    LaunchedEffect(Unit) {
+        if(viewModel.filteredContent.value.isNotEmpty()) {
+            viewModel.selectContent(viewModel.filteredContent.value.first().contentId)
+        }
+    }
+    MaterialTheme { EducationalContentScreen(viewModel = viewModel) }
+}

--- a/app/src/main/java/com/example/rooster/professionaltools/vetnetwork/VeterinaryNetworkScreen.kt
+++ b/app/src/main/java/com/example/rooster/professionaltools/vetnetwork/VeterinaryNetworkScreen.kt
@@ -1,0 +1,433 @@
+package com.example.rooster.professionaltools.vetnetwork
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.update
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import kotlin.random.Random
+
+// --- Data Classes ---
+data class VetProfile(
+    val vetId: String,
+    val fullName: String,
+    val licensedState: String,
+    val licenseNumber: String,
+    val primarySpecialty: String,
+    val secondarySpecialties: List<String> = emptyList(),
+    val clinicName: String,
+    val clinicAddress: String,
+    val contactEmail: String,
+    val contactPhone: String,
+    val yearsOfExperience: Int,
+    val profileBio: String,
+    var acceptingReferrals: Boolean,
+    val areasOfInterest: List<String> = emptyList(),
+    val publicationsLinks: List<String> = emptyList(),
+    val profileVisibility: String = "all_vets", // all_vets, connections_only
+    val lastActiveDate: Date
+) {
+    fun getFormattedLastActive(): String = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(lastActiveDate)
+}
+
+data class ReferralRequest(
+    val requestId: String,
+    val sendingVetId: String,
+    val sendingVetName: String,
+    val receivingVetId: String,
+    val receivingVetName: String,
+    val patientSummary: String,
+    val reasonForReferral: String,
+    val dateSent: Date,
+    var status: String, // pending_review, accepted, declined, information_requested
+    var urgency: String = "Routine", // Routine, Urgent
+    var notes: String? = null, // Notes from receiver
+    var lastUpdatedBy: String? = null,
+    var lastUpdatedAt: Date? = null
+) {
+    fun getFormattedDate(date: Date?): String =
+        date?.let { SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(it) } ?: "N/A"
+}
+
+data class VetSearchFilters(
+    val specialty: String? = null,
+    val location: String? = null,
+    val name: String? = null,
+    val acceptingReferrals: Boolean? = null
+)
+
+// --- ViewModel ---
+class VeterinaryNetworkViewModel(val currentVetId: String = "vet_net_0001") : ViewModel() { // Assume a current vet user
+    private val _allVetProfiles = MutableStateFlow<List<VetProfile>>(emptyList())
+    private val _allReferrals = MutableStateFlow<List<ReferralRequest>>(emptyList())
+
+    private val _filters = MutableStateFlow(VetSearchFilters())
+    val filters: StateFlow<VetSearchFilters> = _filters
+
+    val filteredVetProfiles: StateFlow<List<VetProfile>> = combine(_allVetProfiles, _filters) { profiles, filters ->
+        profiles.filter { vet ->
+            (filters.specialty.isNullOrBlank() || vet.primarySpecialty.contains(filters.specialty, ignoreCase = true) || vet.secondarySpecialties.any { it.contains(filters.specialty,ignoreCase = true) }) &&
+            (filters.location.isNullOrBlank() || vet.clinicAddress.contains(filters.location, ignoreCase = true)) &&
+            (filters.name.isNullOrBlank() || vet.fullName.contains(filters.name, ignoreCase = true)) &&
+            (filters.acceptingReferrals == null || vet.acceptingReferrals == filters.acceptingReferrals)
+        }.sortedBy { it.fullName }
+    }.stateIn(kotlinx.coroutines.MainScope(), kotlinx.coroutines.flow.SharingStarted.WhileSubscribed(5000), emptyList())
+
+    val incomingReferrals: StateFlow<List<ReferralRequest>> = combine(_allReferrals, MutableStateFlow(currentVetId)) { referrals, currentId ->
+        referrals.filter { it.receivingVetId == currentId && it.status == "pending_review" }.sortedByDescending { it.dateSent }
+    }.stateIn(kotlinx.coroutines.MainScope(), kotlinx.coroutines.flow.SharingStarted.WhileSubscribed(5000), emptyList())
+
+    val outgoingReferrals: StateFlow<List<ReferralRequest>> = combine(_allReferrals, MutableStateFlow(currentVetId)) { referrals, currentId ->
+        referrals.filter { it.sendingVetId == currentId && it.status !in listOf("accepted", "declined") }.sortedByDescending { it.dateSent }
+    }.stateIn(kotlinx.coroutines.MainScope(), kotlinx.coroutines.flow.SharingStarted.WhileSubscribed(5000), emptyList())
+
+
+    private val _selectedVetProfile = MutableStateFlow<VetProfile?>(null)
+    val selectedVetProfile: StateFlow<VetProfile?> = _selectedVetProfile
+
+    val specialtiesList = listOf("Any", "General Practice", "Cardiology", "Surgery", "Dermatology", "Oncology", "Neurology", "Livestock Health")
+
+
+    init {
+        loadMockVetProfiles()
+        // Add a mock referral for the currentVetId to see in incoming
+        if(_allVetProfiles.value.size > 1) {
+            val sender = _allVetProfiles.value.first { it.vetId != currentVetId }
+            val receiver = _allVetProfiles.value.first { it.vetId == currentVetId }
+             _allReferrals.update { it + ReferralRequest(
+                requestId = "ref_mock_${Date().time}", sendingVetId = sender.vetId, sendingVetName = sender.fullName,
+                receivingVetId = receiver.vetId, receivingVetName = receiver.fullName,
+                patientSummary = "Mock patient for ${receiver.fullName}", reasonForReferral = "Needs ${receiver.primarySpecialty} consult",
+                dateSent = Date(), status = "pending_review"
+            )}
+        }
+    }
+
+    private fun loadMockVetProfiles(count: Int = 10) {
+        val tempProfiles = mutableListOf<VetProfile>()
+        val baseNames = listOf("Smith", "Jones", "Williams", "Brown", "Davis")
+        val firstNames = listOf("Dr. Emily", "Dr. John", "Dr. Sarah", "Dr. Michael")
+        val cities = listOf("New York, NY", "Ruralville, IA", "Metropolis, IL")
+
+        // Ensure the currentVetId profile exists
+        tempProfiles.add(VetProfile(
+            vetId = currentVetId, fullName = "Dr. Current User (You)", licensedState = "CA", licenseNumber = "VET12345",
+            primarySpecialty = specialtiesList.filterNot{it=="Any"}.random(), clinicName = "My Clinic", clinicAddress = "123 My Street, MyCity, CA",
+            contactEmail = "me@example.com", contactPhone = "555-0000", yearsOfExperience = 10,
+            profileBio = "This is the profile for the current logged-in user.", acceptingReferrals = true,
+            lastActiveDate = Date()
+        ))
+
+        for (i in 0 until count) {
+            val vetId = "vet_net_${(i + 2).toString().padStart(4, '0')}" // Start from 2 as 1 is current user
+            if (vetId == currentVetId) continue // Skip if it's current user's mock ID
+
+            tempProfiles.add(VetProfile(
+                vetId = vetId,
+                fullName = "${firstNames.random()} ${baseNames.random()}",
+                licensedState = listOf("NY", "CA", "TX", "FL").random(),
+                licenseNumber = "VET${Random.nextInt(10000, 99999)}",
+                primarySpecialty = specialtiesList.filterNot{it=="Any"}.random(),
+                secondarySpecialties = specialtiesList.filterNot{it=="Any"}.shuffled().take(Random.nextInt(0,2)),
+                clinicName = "${listOf("Advanced", "Rural", "City", "University").random()} Vet Care",
+                clinicAddress = "${Random.nextInt(100,999)} Main St, ${cities.random()}",
+                contactEmail = "vet$i@example.com", contactPhone = "555-${Random.nextInt(100,999)}-${Random.nextInt(1000,9999)}",
+                yearsOfExperience = Random.nextInt(1,30),
+                profileBio = "Experienced vet in ${specialtiesList.filterNot{it=="Any"}.random()}.",
+                acceptingReferrals = Random.nextBoolean(),
+                lastActiveDate = Date(System.currentTimeMillis() - Random.nextLong(0, 60 * 86400000L))
+            ))
+        }
+        _allVetProfiles.value = tempProfiles
+    }
+
+    fun updateFilters(newFilters: VetSearchFilters) { _filters.value = newFilters }
+    fun selectVetProfile(vetId: String) { _selectedVetProfile.value = _allVetProfiles.value.find { it.vetId == vetId } }
+    fun clearSelectedVetProfile() { _selectedVetProfile.value = null }
+
+    fun sendReferral(receivingVetId: String, patientSummary: String, reason: String): Boolean {
+        val sender = _allVetProfiles.value.find { it.vetId == currentVetId } ?: return false
+        val receiver = _allVetProfiles.value.find { it.vetId == receivingVetId } ?: return false
+        if (!receiver.acceptingReferrals) { println("Warning: Vet not actively accepting referrals."); /* Allow sending anyway for demo */ }
+
+        val newReferral = ReferralRequest(
+            requestId = "ref_${Date().time}", sendingVetId = sender.vetId, sendingVetName = sender.fullName,
+            receivingVetId = receiver.vetId, receivingVetName = receiver.fullName,
+            patientSummary = patientSummary, reasonForReferral = reason, dateSent = Date(), status = "pending_review"
+        )
+        _allReferrals.update { (it + newReferral).sortedByDescending { r -> r.dateSent } }
+        return true
+    }
+
+    fun updateReferralStatus(requestId: String, newStatus: String, notes: String?) {
+        _allReferrals.update { referrals ->
+            referrals.map {
+                if (it.requestId == requestId) {
+                    it.copy(status = newStatus, notes = notes ?: it.notes, lastUpdatedAt = Date(), lastUpdatedBy = currentVetId)
+                } else it
+            }
+        }
+    }
+}
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun VeterinaryNetworkScreen(viewModel: VeterinaryNetworkViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val filteredVets by viewModel.filteredVetProfiles.collectAsState()
+    val selectedVet by viewModel.selectedVetProfile.collectAsState()
+    val incomingReferrals by viewModel.incomingReferrals.collectAsState()
+    val outgoingReferrals by viewModel.outgoingReferrals.collectAsState()
+    val currentFilters by viewModel.filters.collectAsState()
+
+    var showFilterDialog by remember { mutableStateOf(false) }
+    var showReferralDialog by remember { mutableStateOf(false) }
+    var vetToReferTo by remember { mutableStateOf<VetProfile?>(null) }
+    var showUpdateReferralDialog by remember { mutableStateOf(false) }
+    var referralToUpdate by remember { mutableStateOf<ReferralRequest?>(null) }
+
+
+    if (showFilterDialog) {
+        FilterVetsDialog(currentFilters, viewModel, onDismiss = { showFilterDialog = false })
+    }
+    if (showReferralDialog && vetToReferTo != null) {
+        SendReferralDialog(vetToReferTo!!, viewModel, onDismiss = { showReferralDialog = false; vetToReferTo = null })
+    }
+     if (showUpdateReferralDialog && referralToUpdate != null) {
+        UpdateReferralStatusDialog(referralToUpdate!!, viewModel, onDismiss = { showUpdateReferralDialog = false; referralToUpdate = null })
+    }
+
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(if (selectedVet == null) "Veterinary Network" else selectedVet!!.fullName) },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color(0xFF7CB342)), // Light Green
+                navigationIcon = if (selectedVet != null) {
+                    { IconButton(onClick = { viewModel.clearSelectedVetProfile() }) { Icon(Icons.Filled.ArrowBack, "Back") } }
+                } else null,
+                actions = {
+                    if (selectedVet == null) {
+                        IconButton(onClick = { showFilterDialog = true }) { Icon(Icons.Filled.FilterList, "Filter Vets") }
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        if (selectedVet == null) {
+            NetworkDashboard(paddingValues, viewModel, filteredVets, incomingReferrals, outgoingReferrals,
+                onVetClick = { viewModel.selectVetProfile(it.vetId) },
+                onUpdateReferralClick = { referralToUpdate = it; showUpdateReferralDialog = true}
+            )
+        } else {
+            VetProfileDetailScreen(paddingValues, selectedVet!!,
+                onReferClick = { vetToReferTo = it; showReferralDialog = true }
+            )
+        }
+    }
+}
+
+@Composable
+fun NetworkDashboard(
+    paddingValues: PaddingValues, viewModel: VeterinaryNetworkViewModel,
+    filteredVets: List<VetProfile>, incomingReferrals: List<ReferralRequest>, outgoingReferrals: List<ReferralRequest>,
+    onVetClick: (VetProfile) -> Unit, onUpdateReferralClick: (ReferralRequest) -> Unit
+) {
+    LazyColumn(modifier = Modifier.padding(paddingValues).padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        item { SectionTitle("Find Veterinarians (${filteredVets.size})") }
+        if(filteredVets.isEmpty()) item { EmptyState("No vets match criteria.")}
+        items(filteredVets.take(5), key = {it.vetId}) { vet -> VetListItem(vet, onClick = { onVetClick(vet) }) }
+        if(filteredVets.size > 5) item { TextButton(onClick = { /* TODO: Navigate to full list */ }) { Text("View All ${filteredVets.size} Results...")}}
+
+
+        item { SectionTitle("Incoming Referrals (${incomingReferrals.size})") }
+        if(incomingReferrals.isEmpty()) item { EmptyState("No incoming referrals.")}
+        items(incomingReferrals, key = {it.requestId}) { ref -> ReferralRequestItem(ref, true) { onUpdateReferralClick(ref) } }
+
+        item { SectionTitle("Outgoing Referrals (${outgoingReferrals.size})") }
+        if(outgoingReferrals.isEmpty()) item { EmptyState("No pending outgoing referrals.")}
+        items(outgoingReferrals, key = {it.requestId}) { ref -> ReferralRequestItem(ref, false) { /* Maybe allow cancelling */ } }
+    }
+}
+
+@Composable
+fun VetListItem(vet: VetProfile, onClick: () -> Unit) {
+    Card(Modifier.fillMaxWidth().clickable(onClick = onClick), elevation = CardDefaults.cardElevation(2.dp)) {
+        Column(Modifier.padding(12.dp)) {
+            Text(vet.fullName, style = MaterialTheme.typography.titleMedium)
+            Text("${vet.primarySpecialty} at ${vet.clinicName}", style = MaterialTheme.typography.bodyMedium)
+            Text(vet.clinicAddress, style = MaterialTheme.typography.bodySmall)
+            Text("Accepting Referrals: ${if(vet.acceptingReferrals) "Yes" else "No"}", color = if(vet.acceptingReferrals) Color.Green else Color.Red)
+        }
+    }
+}
+
+@Composable
+fun VetProfileDetailScreen(paddingValues: PaddingValues, vet: VetProfile, onReferClick: (VetProfile) -> Unit) {
+    Column(Modifier.padding(paddingValues).padding(16.dp).fillMaxSize().verticalScroll(rememberScrollState()), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(vet.fullName, style = MaterialTheme.typography.headlineMedium)
+        Text("Primary Specialty: ${vet.primarySpecialty}", style = MaterialTheme.typography.titleMedium)
+        if (vet.secondarySpecialties.isNotEmpty()) {
+            Text("Other Specialties: ${vet.secondarySpecialties.joinToString()}", style = MaterialTheme.typography.bodyMedium)
+        }
+        Text("Clinic: ${vet.clinicName}, ${vet.clinicAddress}")
+        Text("Experience: ${vet.yearsOfExperience} years")
+        Text("Contact: ${vet.contactEmail} / ${vet.contactPhone}")
+        Text("License: ${vet.licensedState} - ${vet.licenseNumber}")
+        Text("Bio: ${vet.profileBio}")
+        if (vet.areasOfInterest.isNotEmpty()) Text("Areas of Interest: ${vet.areasOfInterest.joinToString()}")
+        Text("Accepting Referrals: ${if(vet.acceptingReferrals) "Yes" else "No"}", fontWeight = FontWeight.Bold)
+        Text("Last Active: ${vet.getFormattedLastActive()}")
+
+        if(vet.acceptingReferrals) {
+            Button(onClick = { onReferClick(vet) }, modifier = Modifier.align(Alignment.CenterHorizontally).padding(top = 16.dp)) {
+                Icon(Icons.Filled.Send, "Refer Case"); Spacer(Modifier.width(4.dp)); Text("Refer a Case")
+            }
+        }
+    }
+}
+
+@Composable
+fun ReferralRequestItem(ref: ReferralRequest, isIncoming: Boolean, onClick: () -> Unit) {
+    Card(Modifier.fillMaxWidth().clickable(onClick = onClick), elevation = CardDefaults.cardElevation(1.dp)) {
+        Column(Modifier.padding(12.dp)) {
+            Text(if(isIncoming) "From: ${ref.sendingVetName}" else "To: ${ref.receivingVetName}", style = MaterialTheme.typography.titleMedium)
+            Text("Patient: ${ref.patientSummary.take(50)}...", style = MaterialTheme.typography.bodyMedium)
+            Text("Reason: ${ref.reasonForReferral.take(50)}...", style = MaterialTheme.typography.bodySmall)
+            Text("Sent: ${ref.getFormattedDate(ref.dateSent)}, Status: ${ref.status}", style = MaterialTheme.typography.bodySmall)
+        }
+    }
+}
+
+@Composable
+fun FilterVetsDialog(filters: VetSearchFilters, viewModel: VeterinaryNetworkViewModel, onDismiss: () -> Unit) {
+    var specialty by remember { mutableStateOf(filters.specialty ?: viewModel.specialtiesList.first()) }
+    var location by remember { mutableStateOf(filters.location ?: "") }
+    var name by remember { mutableStateOf(filters.name ?: "") }
+    var accepting by remember { mutableStateOf(filters.acceptingReferrals) } // null, true, false
+
+    AlertDialog(
+        onDismissRequest = onDismiss, title = { Text("Filter Veterinarians") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                ExposedDropdownMenuForOptions("Specialty", viewModel.specialtiesList, specialty) { specialty = it }
+                OutlinedTextField(value = location, onValueChange = {location=it}, label = {Text("Location Keyword")})
+                OutlinedTextField(value = name, onValueChange = {name=it}, label = {Text("Name Keyword")})
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text("Accepting Referrals: ")
+                    RadioButton(selected = accepting == true, onClick = { accepting = true }); Text("Yes")
+                    RadioButton(selected = accepting == false, onClick = { accepting = false }); Text("No")
+                    RadioButton(selected = accepting == null, onClick = { accepting = null }); Text("Any")
+                }
+            }
+        },
+        confirmButton = { Button(onClick = {
+            viewModel.updateFilters(VetSearchFilters(
+                specialty = if(specialty == "Any") null else specialty,
+                location = location.ifBlank { null }, name = name.ifBlank { null }, acceptingReferrals = accepting
+            ))
+            onDismiss()
+        }) {Text("Apply Filters")} },
+        dismissButton = { Button(onClick = onDismiss) {Text("Cancel")} }
+    )
+}
+
+@Composable
+fun SendReferralDialog(vetToReferTo: VetProfile, viewModel: VeterinaryNetworkViewModel, onDismiss: () -> Unit) {
+    var patientSummary by remember { mutableStateOf("") }
+    var reason by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onDismiss, title = { Text("Refer Case to ${vetToReferTo.fullName}")},
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(value = patientSummary, onValueChange = {patientSummary=it}, label={Text("Patient Summary (e.g. Species, Age, Condition)")}, minLines = 3)
+                OutlinedTextField(value = reason, onValueChange = {reason=it}, label={Text("Reason for Referral")}, minLines = 2)
+            }
+        },
+        confirmButton = { Button(onClick = {
+            if(patientSummary.isNotBlank() && reason.isNotBlank()) {
+                viewModel.sendReferral(vetToReferTo.vetId, patientSummary, reason)
+                onDismiss()
+            }
+        }, enabled = patientSummary.isNotBlank() && reason.isNotBlank()) {Text("Send Referral")} },
+        dismissButton = { Button(onClick = onDismiss) {Text("Cancel")} }
+    )
+}
+
+@Composable
+fun UpdateReferralStatusDialog(referral: ReferralRequest, viewModel: VeterinaryNetworkViewModel, onDismiss: () -> Unit) {
+    val statuses = listOf("accepted", "declined", "information_requested") // Possible actions by receiver
+    var newStatus by remember { mutableStateOf(statuses.first())}
+    var notes by remember { mutableStateOf(referral.notes ?: "")}
+    AlertDialog(
+        onDismissRequest = onDismiss, title = {Text("Update Referral from ${referral.sendingVetName}")},
+        text = {
+             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text("Patient: ${referral.patientSummary.take(100)}...")
+                ExposedDropdownMenuForOptions("New Status", statuses, newStatus) {newStatus = it}
+                OutlinedTextField(value = notes, onValueChange = {notes=it}, label={Text("Notes (Optional)")})
+            }
+        },
+        confirmButton = { Button(onClick = {
+            viewModel.updateReferralStatus(referral.requestId, newStatus, notes)
+            onDismiss()
+        }) {Text("Update Status")}},
+        dismissButton = { Button(onClick = onDismiss) {Text("Cancel")}}
+    )
+}
+
+
+// Re-using ExposedDropdownMenuForOptions
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ExposedDropdownMenuForOptions(label: String, options: List<String>, selectedOption: String, onOptionSelected: (String) -> Unit) {
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = !expanded }) {
+        OutlinedTextField(value = selectedOption, onValueChange = {}, readOnly = true, label = { Text(label) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier.menuAnchor().fillMaxWidth()
+        )
+        ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            options.forEach { option -> DropdownMenuItem(text = { Text(option) }, onClick = { onOptionSelected(option); expanded = false }) }
+        }
+    }
+}
+@Composable
+fun SectionTitle(title: String) = Text(title, style = MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(top = 16.dp, bottom = 8.dp))
+@Composable
+fun EmptyState(message: String) = Text(message, modifier = Modifier.padding(vertical = 8.dp).fillMaxWidth(), textAlign = androidx.compose.ui.text.style.TextAlign.Center)
+
+
+@Preview(showBackground = true, heightDp = 1000)
+@Composable
+fun PreviewVeterinaryNetworkScreen_Dashboard() {
+    MaterialTheme { VeterinaryNetworkScreen(viewModel = VeterinaryNetworkViewModel("vet_net_0001")) }
+}
+
+@Preview(showBackground = true, heightDp = 800)
+@Composable
+fun PreviewVeterinaryNetworkScreen_ProfileDetail() {
+    val viewModel = VeterinaryNetworkViewModel("vet_net_0001")
+    LaunchedEffect(Unit){
+        if(viewModel.filteredVetProfiles.value.isNotEmpty()){
+            viewModel.selectVetProfile(viewModel.filteredVetProfiles.value.first { it.vetId != viewModel.currentVetId }.vetId)
+        }
+    }
+    MaterialTheme { VeterinaryNetworkScreen(viewModel = viewModel) }
+}

--- a/app/src/main/java/com/example/rooster/ui/components/AppBottomNavigationBar.kt
+++ b/app/src/main/java/com/example/rooster/ui/components/AppBottomNavigationBar.kt
@@ -232,8 +232,49 @@ private fun getNavigationItemsForRole(userRole: UserRole): List<NavigationItem> 
                     icon = Icons.Default.Person,
                     label = "Profile",
                 ),
+                // Custom Admin/Vet sections
+                NavigationItem(
+                    route = com.example.rooster.NavigationRoute.AdminFeaturesDashboard.route, // Assuming NavigationRoute is accessible
+                    icon = Icons.Default.AdminPanelSettings,
+                    label = "Admin"
+                ),
+                NavigationItem(
+                    route = com.example.rooster.NavigationRoute.FinancialsFeaturesDashboard.route,
+                    icon = Icons.Default.MonetizationOn,
+                    label = "Financials"
+                ),
+                 NavigationItem(
+                    route = com.example.rooster.NavigationRoute.VeterinaryFeaturesDashboard.route,
+                    icon = Icons.Default.MedicalServices, // Or LocalHospital
+                    label = "Veterinary"
+                ),
+                NavigationItem(
+                    route = com.example.rooster.NavigationRoute.ProfessionalToolsDashboard.route,
+                    icon = Icons.Default.Build, // Placeholder icon
+                    label = "Pro Tools"
+                )
             )
-
+        // Add a specific case for VETERINARIAN if its items differ significantly from HIGH_LEVEL
+        // For now, VETERINARIAN uses HIGH_LEVEL items as per MainActivity logic.
+        // If UserRole.VETERINARIAN is distinct and needs specific items different from ADMIN:
+        /*
+        UserRole.VETERINARIAN ->
+            listOf(
+                // Common items perhaps
+                NavigationItem(route = "dashboard", icon = Icons.Default.Dashboard, label = "Dashboard"), // Or a vet specific home
+                NavigationItem(
+                    route = com.example.rooster.NavigationRoute.VeterinaryFeaturesDashboard.route,
+                    icon = Icons.Default.MedicalServices,
+                    label = "Veterinary"
+                ),
+                NavigationItem(
+                    route = com.example.rooster.NavigationRoute.ProfessionalToolsDashboard.route,
+                    icon = Icons.Default.Build,
+                    label = "Pro Tools"
+                ),
+                NavigationItem(route = "profile", icon = Icons.Default.Person, label = "Profile")
+            )
+        */
         UserRole.UNKNOWN -> emptyList()
     }
 }

--- a/app/src/main/java/com/example/rooster/veterinary/VeterinaryDashboardScreen.kt
+++ b/app/src/main/java/com/example/rooster/veterinary/VeterinaryDashboardScreen.kt
@@ -1,0 +1,88 @@
+package com.example.rooster.veterinary
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.example.rooster.veterinary.healthalerts.HealthAlertSystemScreen
+import com.example.rooster.veterinary.patienthistory.PatientHistoryScreen
+import com.example.rooster.veterinary.prescriptions.PrescriptionManagementScreen
+import com.example.rooster.veterinary.telemedicine.TelemedicineScreen
+import com.example.rooster.veterinary.consultations.VetConsultationScreen
+
+object VeterinaryDestinations {
+    const val DASHBOARD = "veterinary_dashboard"
+    const val HEALTH_ALERTS = "veterinary_health_alerts"
+    const val PATIENT_HISTORY = "veterinary_patient_history"
+    const val PRESCRIPTIONS = "veterinary_prescriptions"
+    const val TELEMEDICINE = "veterinary_telemedicine"
+    const val CONSULTATIONS = "veterinary_consultations"
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun VeterinaryDashboardScreen(navController: NavController) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Veterinary Dashboard") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color(0xFF673AB7)) // Deep Purple
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxSize()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            item { VeterinaryDashboardButton(navController, "Health Alert System", VeterinaryDestinations.HEALTH_ALERTS) }
+            item { VeterinaryDashboardButton(navController, "Patient History", VeterinaryDestinations.PATIENT_HISTORY) }
+            item { VeterinaryDashboardButton(navController, "Prescription Management", VeterinaryDestinations.PRESCRIPTIONS) }
+            item { VeterinaryDashboardButton(navController, "Telemedicine", VeterinaryDestinations.TELEMEDICINE) }
+            item { VeterinaryDashboardButton(navController, "Vet Consultation Scheduler", VeterinaryDestinations.CONSULTATIONS) }
+        }
+    }
+}
+
+@Composable
+fun VeterinaryDashboardButton(navController: NavController, text: String, route: String) {
+    Button(
+        onClick = { navController.navigate(route) },
+        modifier = Modifier.fillMaxWidth(0.8f).height(50.dp)
+    ) {
+        Text(text)
+    }
+}
+
+@Composable
+fun VeterinaryFeatureNavigator() {
+    val navController = rememberNavController()
+    NavHost(navController = navController, startDestination = VeterinaryDestinations.DASHBOARD) {
+        composable(VeterinaryDestinations.DASHBOARD) { VeterinaryDashboardScreen(navController) }
+        composable(VeterinaryDestinations.HEALTH_ALERTS) { HealthAlertSystemScreen() }
+        composable(VeterinaryDestinations.PATIENT_HISTORY) { PatientHistoryScreen() }
+        composable(VeterinaryDestinations.PRESCRIPTIONS) { PrescriptionManagementScreen() }
+        composable(VeterinaryDestinations.TELEMEDICINE) { TelemedicineScreen() }
+        composable(VeterinaryDestinations.CONSULTATIONS) { VetConsultationScreen() }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewVeterinaryDashboardScreen() {
+    MaterialTheme {
+        VeterinaryFeatureNavigator()
+    }
+}

--- a/app/src/main/java/com/example/rooster/veterinary/consultations/VetConsultationScreen.kt
+++ b/app/src/main/java/com/example/rooster/veterinary/consultations/VetConsultationScreen.kt
@@ -1,0 +1,397 @@
+package com.example.rooster.veterinary.consultations
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.PersonAdd
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+import kotlin.random.Random
+
+// --- Data Classes ---
+data class VetProfile(
+    val vetId: String,
+    val name: String,
+    val specialty: String,
+    var availability: Map<String, List<String>>, // Date string to list of time slots (e.g., "HH:mm")
+    val consultationFee: Double
+)
+
+data class Appointment(
+    val appointmentId: String,
+    val vetId: String,
+    val vetName: String,
+    val userId: String,
+    val patientName: String,
+    val appointmentDateTime: Date,
+    val reason: String,
+    var status: String // booked, completed, cancelled, in_progress
+) {
+    fun getFormattedDateTime(): String = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(appointmentDateTime)
+}
+
+data class PatientQueueEntry(
+    val queueId: String,
+    val userId: String,
+    val patientName: String,
+    val arrivalTime: Date,
+    val reason: String,
+    var assignedVetId: String? = null,
+    var assignedVetName: String? = null, // For display
+    var status: String = "waiting" // waiting, assigned, in_consultation
+) {
+    fun getFormattedArrivalTime(): String = SimpleDateFormat("HH:mm:ss", Locale.getDefault()).format(arrivalTime)
+}
+
+// --- ViewModel ---
+class VetConsultationViewModel : ViewModel() {
+    private val _vets = MutableStateFlow<List<VetProfile>>(emptyList())
+    val vets: StateFlow<List<VetProfile>> = _vets
+
+    private val _appointments = MutableStateFlow<List<Appointment>>(emptyList())
+    val appointments: StateFlow<List<Appointment>> = _appointments
+
+    private val _patientQueue = MutableStateFlow<List<PatientQueueEntry>>(emptyList())
+    val patientQueue: StateFlow<List<PatientQueueEntry>> = _patientQueue
+
+    val specialties = listOf("General Practice", "Surgery", "Dermatology", "Livestock Specialist", "Cardiology")
+    val mockPatientNames = listOf("Bessie", "Charlie", "Daisy", "Rocky", "Lucy", "Max", "Speckles")
+    val mockReasons = listOf("General check-up", "Vaccination", "Skin issue", "Limping", "Not eating", "Urgent concern")
+
+
+    init {
+        loadMockData()
+    }
+
+    private fun generateMockAvailability(numDays: Int = 7): Map<String, List<String>> {
+        val availability = mutableMapOf<String, List<String>>()
+        val today = Calendar.getInstance()
+        for (i in 0 until numDays) {
+            val dayCal = today.clone() as Calendar
+            dayCal.add(Calendar.DATE, i)
+            if (dayCal.get(Calendar.DAY_OF_WEEK) == Calendar.SATURDAY || dayCal.get(Calendar.DAY_OF_WEEK) == Calendar.SUNDAY) continue
+
+            val timeSlots = mutableListOf<String>()
+            for (j in 0..4) { // 5 slots per day
+                val hour = 9 + j
+                if (Random.nextBoolean()) { // Slot available?
+                    timeSlots.add(String.format("%02d:00", hour))
+                }
+            }
+            if (timeSlots.isNotEmpty()) {
+                availability[SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(dayCal.time)] = timeSlots
+            }
+        }
+        return availability
+    }
+
+    private fun loadMockData() {
+        val vetNames = listOf("Dr. Alice Smith", "Dr. Bob Johnson", "Dr. Carol White", "Dr. David Brown")
+        val tempVets = vetNames.mapIndexed { i, name ->
+            VetProfile(
+                vetId = "vet${(i + 1).toString().padStart(3, '0')}",
+                name = name,
+                specialty = specialties.random(),
+                availability = generateMockAvailability(),
+                consultationFee = Random.nextDouble(50.0, 150.0)
+            )
+        }
+        _vets.value = tempVets
+
+        val tempAppointments = mutableListOf<Appointment>()
+        // Create some mock appointments
+        _appointments.value = tempAppointments.sortedBy { it.appointmentDateTime }
+
+        val tempQueue = (1..3).map { i ->
+            PatientQueueEntry(
+                queueId = "q_${Date().time}_$i",
+                userId = "farmer${Random.nextInt(1,5).toString().padStart(3,'0')}",
+                patientName = mockPatientNames.random(),
+                arrivalTime = Date(System.currentTimeMillis() - Random.nextLong(5, 30) * 60000L),
+                reason = mockReasons.random()
+            )
+        }.toMutableList()
+        _patientQueue.value = tempQueue.sortedBy { it.arrivalTime }
+    }
+
+    fun bookAppointment(vetId: String, userId: String, patientName: String, dateStr: String, timeStr: String, reason: String): Boolean {
+        val vet = _vets.value.find { it.vetId == vetId } ?: return false
+        val slotsForDate = vet.availability[dateStr] ?: return false
+        if (!slotsForDate.contains(timeStr)) return false
+
+        // Remove slot (simplified)
+        val updatedAvailability = vet.availability.toMutableMap()
+        updatedAvailability[dateStr] = slotsForDate.filterNot { it == timeStr }
+        _vets.update { list -> list.map { if (it.vetId == vetId) it.copy(availability = updatedAvailability) else it } }
+
+        val appointmentDateTime = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).parse("$dateStr $timeStr") ?: Date()
+        val newAppointment = Appointment(
+            appointmentId = "appt_${Date().time}", vetId = vetId, vetName = vet.name, userId = userId,
+            patientName = patientName, appointmentDateTime = appointmentDateTime, reason = reason, status = "booked"
+        )
+        _appointments.update { (it + newAppointment).sortedBy { appt -> appt.appointmentDateTime } }
+        return true
+    }
+
+    fun addToQueue(userId: String, patientName: String, reason: String) {
+        val newEntry = PatientQueueEntry(
+            queueId = "q_${Date().time}_${Random.nextInt(100)}", userId = userId, patientName = patientName,
+            arrivalTime = Date(), reason = reason
+        )
+        _patientQueue.update { (it + newEntry).sortedBy { entry -> entry.arrivalTime } }
+    }
+
+    fun assignQueuedPatient(queueId: String, vetId: String) {
+        val vet = _vets.value.find { it.vetId == vetId } ?: return
+        _patientQueue.update { queue ->
+            queue.map {
+                if (it.queueId == queueId && it.assignedVetId == null)
+                    it.copy(assignedVetId = vetId, assignedVetName = vet.name, status = "assigned")
+                else it
+            }
+        }
+    }
+}
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun VetConsultationScreen(viewModel: VetConsultationViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val vets by viewModel.vets.collectAsState()
+    val appointments by viewModel.appointments.collectAsState()
+    val patientQueue by viewModel.patientQueue.collectAsState()
+
+    var showBookingDialog by remember { mutableStateOf(false) }
+    var vetForBooking by remember { mutableStateOf<VetProfile?>(null) }
+    var showAddToQueueDialog by remember { mutableStateOf(false) }
+
+    if (showBookingDialog && vetForBooking != null) {
+        BookingDialog(vet = vetForBooking!!, viewModel = viewModel, onDismiss = { showBookingDialog = false; vetForBooking = null })
+    }
+    if(showAddToQueueDialog) {
+        AddToQueueDialog(viewModel = viewModel, onDismiss = { showAddToQueueDialog = false })
+    }
+
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("Vet Consultation") }, colors = TopAppBarDefaults.topAppBarColors(containerColor = Color(0xFF00ACC1))) }, // Cyan
+        floatingActionButton = {
+            FloatingActionButton(onClick = { showAddToQueueDialog = true }) {
+                Icon(Icons.Filled.PersonAdd, "Add to Walk-in Queue")
+            }
+        }
+    ) { paddingValues ->
+        LazyColumn(modifier = Modifier.padding(paddingValues).padding(16.dp)) {
+            item { SectionTitle("Available Veterinarians") }
+            items(vets, key = {it.vetId}) { vet -> VetCard(vet) { selectedVet -> vetForBooking = selectedVet; showBookingDialog = true } }
+
+            item { SectionTitle("Upcoming Appointments (${appointments.filter{it.status == "booked" && it.appointmentDateTime >= Date()}.size})") }
+            val upcomingAppointments = appointments.filter{it.status == "booked" && it.appointmentDateTime >= Date()}.take(5)
+            if(upcomingAppointments.isEmpty()) item { EmptyState("No upcoming appointments.")}
+            items(upcomingAppointments, key = {it.appointmentId}) { appt -> AppointmentCard(appt) }
+
+            item { SectionTitle("Patient Queue (${patientQueue.size})") }
+             if(patientQueue.isEmpty()) item { EmptyState("Patient queue is empty.")}
+            items(patientQueue, key = {it.queueId}) { entry -> PatientQueueCard(entry, vets, viewModel) }
+        }
+    }
+}
+
+@Composable
+fun SectionTitle(title: String) = Text(title, style = MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(top = 16.dp, bottom = 8.dp))
+@Composable
+fun EmptyState(message: String) = Text(message, modifier = Modifier.padding(vertical = 8.dp).fillMaxWidth(), textAlign = androidx.compose.ui.text.style.TextAlign.Center)
+
+
+@Composable
+fun VetCard(vet: VetProfile, onBookClick: (VetProfile) -> Unit) {
+    Card(Modifier.fillMaxWidth().padding(vertical = 4.dp), elevation = CardDefaults.cardElevation(2.dp)) {
+        Column(Modifier.padding(12.dp)) {
+            Text("${vet.name} - ${vet.specialty}", style = MaterialTheme.typography.titleMedium)
+            Text("Fee: $${"%.2f".format(vet.consultationFee)}")
+            // Display first few available slots as example
+            vet.availability.entries.firstOrNull()?.let { (date, slots) ->
+                if (slots.isNotEmpty()) Text("Next Available: $date at ${slots.first()}", style = MaterialTheme.typography.bodySmall)
+                else Text("No immediate slots shown", style = MaterialTheme.typography.bodySmall)
+            } ?: Text("Availability not shown", style = MaterialTheme.typography.bodySmall)
+            Button(onClick = { onBookClick(vet) }, modifier = Modifier.align(Alignment.End).padding(top=4.dp)) { Text("Book Appointment") }
+        }
+    }
+}
+
+@Composable
+fun AppointmentCard(appt: Appointment) {
+    Card(Modifier.fillMaxWidth().padding(vertical = 4.dp), elevation = CardDefaults.cardElevation(1.dp)) {
+        Column(Modifier.padding(12.dp)) {
+            Text("Patient: ${appt.patientName} with ${appt.vetName}", style = MaterialTheme.typography.titleMedium)
+            Text("On: ${appt.getFormattedDateTime()} for ${appt.reason}")
+            Text("Status: ${appt.status}", color = if (appt.status == "booked") Color.Blue else Color.DarkGray)
+        }
+    }
+}
+
+@Composable
+fun PatientQueueCard(entry: PatientQueueEntry, vets: List<VetProfile>, viewModel: VetConsultationViewModel) {
+    var showAssignVetDialog by remember { mutableStateOf(false) }
+
+    if (showAssignVetDialog) {
+        AssignVetDialog(entry, vets, viewModel, onDismiss = { showAssignVetDialog = false })
+    }
+
+    Card(Modifier.fillMaxWidth().padding(vertical = 4.dp), elevation = CardDefaults.cardElevation(1.dp)) {
+        Column(Modifier.padding(12.dp)) {
+            Text("Patient: ${entry.patientName} (User: ${entry.userId})", style = MaterialTheme.typography.titleMedium)
+            Text("Arrived: ${entry.getFormattedArrivalTime()}, Reason: ${entry.reason}")
+            Text("Status: ${entry.status}", fontWeight = androidx.compose.ui.text.font.FontWeight.Bold)
+            entry.assignedVetName?.let { Text("Assigned to: $it") }
+            if (entry.assignedVetId == null) {
+                Button(onClick = { showAssignVetDialog = true }, modifier = Modifier.align(Alignment.End).padding(top=4.dp)) {
+                    Text("Assign Vet")
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BookingDialog(vet: VetProfile, viewModel: VetConsultationViewModel, onDismiss: () -> Unit) {
+    var selectedDate by remember { mutableStateOf(vet.availability.keys.firstOrNull() ?: "") }
+    var selectedTime by remember { mutableStateOf(vet.availability[selectedDate]?.firstOrNull() ?: "") }
+    var patientName by remember { mutableStateOf(viewModel.mockPatientNames.first()) }
+    var reason by remember { mutableStateOf(viewModel.mockReasons.first()) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Book with ${vet.name}") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                ExposedDropdownMenuForOptions("Date", vet.availability.keys.toList(), selectedDate) { date ->
+                    selectedDate = date
+                    selectedTime = vet.availability[date]?.firstOrNull() ?: ""
+                }
+                if (selectedDate.isNotEmpty()) {
+                    ExposedDropdownMenuForOptions("Time", vet.availability[selectedDate] ?: emptyList(), selectedTime) { selectedTime = it }
+                }
+                ExposedDropdownMenuForOptions("Patient", viewModel.mockPatientNames, patientName) { patientName = it }
+                ExposedDropdownMenuForOptions("Reason", viewModel.mockReasons, reason) { reason = it }
+            }
+        },
+        confirmButton = {
+            Button(onClick = {
+                if (selectedDate.isNotBlank() && selectedTime.isNotBlank()) {
+                    viewModel.bookAppointment(vet.vetId, "user_currentUser", patientName, selectedDate, selectedTime, reason)
+                }
+                onDismiss()
+            }, enabled = selectedDate.isNotBlank() && selectedTime.isNotBlank()) { Text("Book") }
+        },
+        dismissButton = { Button(onClick = onDismiss) { Text("Cancel") } }
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddToQueueDialog(viewModel: VetConsultationViewModel, onDismiss: () -> Unit) {
+    var patientName by remember { mutableStateOf(viewModel.mockPatientNames.first()) }
+    var reason by remember { mutableStateOf(viewModel.mockReasons.first()) }
+    var userId by remember { mutableStateOf("farmer_walkin_user") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Add Patient to Queue")},
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                 ExposedDropdownMenuForOptions("Patient", viewModel.mockPatientNames, patientName) { patientName = it }
+                 ExposedDropdownMenuForOptions("Reason", viewModel.mockReasons, reason) { reason = it }
+                 OutlinedTextField(value = userId, onValueChange = {userId = it}, label = {Text("User ID (Optional)")})
+            }
+        },
+        confirmButton = { Button(onClick = {
+            viewModel.addToQueue(userId.ifBlank { "anonymous_user" }, patientName, reason)
+            onDismiss()
+        }) {Text("Add to Queue")}},
+        dismissButton = { Button(onClick = onDismiss) {Text("Cancel")}}
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AssignVetDialog(entry: PatientQueueEntry, vets: List<VetProfile>, viewModel: VetConsultationViewModel, onDismiss: () -> Unit){
+    var selectedVetId by remember { mutableStateOf(vets.firstOrNull()?.vetId ?: "")}
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {Text("Assign Vet for ${entry.patientName}")},
+        text = {
+            ExposedDropdownMenuForOptions("Select Vet", vets.map { "${it.name} (${it.vetId})" }, vets.find{it.vetId == selectedVetId}?.let{"${it.name} (${it.vetId})"} ?: "Select Vet") {
+                selectedVetId = it.substringAfterLast("(").substringBeforeLast(")") // Extract ID
+            }
+        },
+        confirmButton = { Button(onClick = {
+            if(selectedVetId.isNotBlank()) viewModel.assignQueuedPatient(entry.queueId, selectedVetId)
+            onDismiss()
+        }, enabled = selectedVetId.isNotBlank()) {Text("Assign")}},
+        dismissButton = { Button(onClick = onDismiss) {Text("Cancel")}}
+    )
+}
+
+
+// Re-using ExposedDropdownMenuForOptions, assuming it's accessible
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ExposedDropdownMenuForOptions( // Copied for standalone preview if needed
+    label: String,
+    options: List<String>,
+    selectedOption: String,
+    onOptionSelected: (String) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = !expanded }
+    ) {
+        OutlinedTextField(
+            value = selectedOption,
+            onValueChange = {}, readOnly = true,
+            label = { Text(label) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier.menuAnchor().fillMaxWidth()
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            options.forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(option) },
+                    onClick = {
+                        onOptionSelected(option)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, heightDp = 1000)
+@Composable
+fun PreviewVetConsultationScreen() {
+    MaterialTheme {
+        VetConsultationScreen(viewModel = VetConsultationViewModel())
+    }
+}

--- a/app/src/main/java/com/example/rooster/veterinary/healthalerts/HealthAlertSystemScreen.kt
+++ b/app/src/main/java/com/example/rooster/veterinary/healthalerts/HealthAlertSystemScreen.kt
@@ -1,0 +1,437 @@
+package com.example.rooster.veterinary.healthalerts
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.NotificationsActive
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import kotlin.random.Random
+
+// --- Data Classes ---
+data class GeoCoordinates(val latitude: Double, val longitude: Double)
+data class CaseUpdate(val timestamp: Date, val note: String, val updatedBy: String? = null) {
+    fun getFormattedTimestamp(): String = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(timestamp)
+}
+
+data class ReportedCase(
+    val caseId: String,
+    var diseaseName: String,
+    var location: String,
+    var geoCoordinates: GeoCoordinates,
+    var affectedRadiusKm: Double,
+    val dateReported: Date,
+    var numberOfConfirmedCases: Int,
+    var numberOfSuspectedCases: Int,
+    var affectedSpecies: List<String>,
+    var severity: String, // Low, Medium, High, Critical
+    var sourceOfReport: String,
+    var status: String, // under_investigation, monitoring, contained, resolved
+    var updates: MutableList<CaseUpdate> = mutableListOf()
+) {
+    fun getFormattedDateReported(): String = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(dateReported)
+}
+
+data class HealthAlert(
+    val alertId: String,
+    val basedOnCaseId: String,
+    val diseaseName: String,
+    val locationSummary: String,
+    val severity: String,
+    val dateIssued: Date,
+    val targetAudience: String,
+    val alertMessage: String,
+    val preventativeMeasuresLink: String,
+    var status: String // active, superseded, cancelled
+) {
+    fun getFormattedDateIssued(): String = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(dateIssued)
+}
+
+
+// --- ViewModel ---
+class HealthAlertViewModel : ViewModel() {
+    private val _reportedCases = MutableStateFlow<List<ReportedCase>>(emptyList())
+    val reportedCases: StateFlow<List<ReportedCase>> = _reportedCases
+
+    private val _activeAlerts = MutableStateFlow<List<HealthAlert>>(emptyList())
+    val activeAlerts: StateFlow<List<HealthAlert>> = _activeAlerts
+
+    // Mock data for dropdowns etc.
+    val knownDiseases = listOf("Avian Influenza", "Foot and Mouth Disease", "Rabies", "Swine Flu", "Bluetongue")
+    val severities = listOf("Low", "Medium", "High", "Critical")
+    val caseStatuses = listOf("under_investigation", "monitoring", "contained", "resolved")
+    val speciesList = listOf("Cattle", "Poultry", "Swine", "Sheep", "Goats", "Horses", "Dogs", "Cats")
+
+
+    init {
+        loadMockData()
+    }
+
+    private fun loadMockData() {
+        val now = Date()
+        val initialCases = mutableListOf<ReportedCase>()
+        for (i in 1..3) {
+            val reportDate = Date(now.time - Random.nextLong(1, 30) * 86400000L)
+            initialCases.add(
+                ReportedCase(
+                    caseId = "case_${reportDate.time}_$i",
+                    diseaseName = knownDiseases.random(),
+                    location = "Location $i, ST",
+                    geoCoordinates = GeoCoordinates(Random.nextDouble(30.0, 40.0), Random.nextDouble(-90.0, -80.0)),
+                    affectedRadiusKm = Random.nextDouble(10.0, 50.0),
+                    dateReported = reportDate,
+                    numberOfConfirmedCases = Random.nextInt(1, 20),
+                    numberOfSuspectedCases = Random.nextInt(5, 50),
+                    affectedSpecies = speciesList.shuffled().take(Random.nextInt(1,3)),
+                    severity = severities.random(),
+                    sourceOfReport = "Vet Clinic $i",
+                    status = caseStatuses.random(),
+                    updates = mutableListOf(CaseUpdate(reportDate, "Initial report"))
+                )
+            )
+        }
+        _reportedCases.value = initialCases.sortedByDescending { it.dateReported }
+        generateAlertsFromCases()
+    }
+
+    private fun generateAlertsFromCases() {
+        val newAlerts = mutableListOf<HealthAlert>()
+        _reportedCases.value.forEach { case ->
+            if (case.severity in listOf("High", "Critical") && case.status !in listOf("resolved", "contained")) {
+                if (_activeAlerts.value.none { it.basedOnCaseId == case.caseId && it.status == "active"}) {
+                     newAlerts.add(
+                        HealthAlert(
+                            alertId = "alert_${case.caseId}",
+                            basedOnCaseId = case.caseId,
+                            diseaseName = case.diseaseName,
+                            locationSummary = case.location,
+                            severity = case.severity,
+                            dateIssued = Date(case.dateReported.time + Random.nextLong(1, 6) * 3600000L), // Issued a bit after report
+                            targetAudience = "Users within ${case.affectedRadiusKm.toInt()}km",
+                            alertMessage = "WARNING: ${case.severity} risk of ${case.diseaseName} near ${case.location}. Affects: ${case.affectedSpecies.joinToString()}. Take precautions.",
+                            preventativeMeasuresLink = "https://example.com/alerts/${case.diseaseName.lowercase().replace(" ", "-")}",
+                            status = "active"
+                        )
+                    )
+                }
+            }
+        }
+        _activeAlerts.update { (it + newAlerts).distinctBy { alert -> alert.alertId }.sortedByDescending { alert -> alert.dateIssued } }
+    }
+
+    fun reportNewCase(disease: String, location: String, lat: Double, lon: Double, radius: Double, confirmed: Int, suspected: Int, species: List<String>, severity: String, source: String, notes: String, reporterId: String) {
+        val reportDate = Date()
+        val newCase = ReportedCase(
+            caseId = "case_${reportDate.time}_${Random.nextInt(1000)}",
+            diseaseName = disease, location = location, geoCoordinates = GeoCoordinates(lat, lon),
+            affectedRadiusKm = radius, dateReported = reportDate, numberOfConfirmedCases = confirmed,
+            numberOfSuspectedCases = suspected, affectedSpecies = species, severity = severity,
+            sourceOfReport = source, status = "under_investigation",
+            updates = mutableListOf(CaseUpdate(reportDate, notes, reporterId))
+        )
+        _reportedCases.update { (listOf(newCase) + it).sortedByDescending { c -> c.dateReported } }
+        if (severity in listOf("High", "Critical")) {
+            generateAlertsFromCases() // Re-evaluate alerts
+        }
+    }
+
+    fun updateCaseStatus(caseId: String, newStatus: String, notes: String, adminId: String) {
+        _reportedCases.update { cases ->
+            cases.map {
+                if (it.caseId == caseId) {
+                    it.copy(status = newStatus, updates = (it.updates + CaseUpdate(Date(), notes, adminId)).toMutableList())
+                } else it
+            }
+        }
+        generateAlertsFromCases() // Status change might affect alerts
+    }
+     fun createAlertFromCase(caseId: String, customMessage: String?, adminId: String){
+         val case = _reportedCases.value.find{ it.caseId == caseId} ?: return
+         if (_activeAlerts.value.any { it.basedOnCaseId == case.caseId && it.status == "active" }) return // Avoid duplicate
+
+         val alert = HealthAlert(
+            alertId = "alert_manual_${case.caseId}_${Date().time}",
+            basedOnCaseId = case.caseId,
+            diseaseName = case.diseaseName,
+            locationSummary = case.location,
+            severity = case.severity,
+            dateIssued = Date(),
+            targetAudience = "Users within ${case.affectedRadiusKm.toInt()}km (Manual Alert by $adminId)",
+            alertMessage = customMessage ?: "MANUAL ALERT by $adminId: ${case.severity} risk of ${case.diseaseName} near ${case.location}. Affects: ${case.affectedSpecies.joinToString()}.",
+            preventativeMeasuresLink = "https://example.com/alerts/${case.diseaseName.lowercase().replace(" ", "-")}",
+            status = "active"
+        )
+        _activeAlerts.update { (listOf(alert) + it).distinctBy {a -> a.alertId}.sortedByDescending { a -> a.dateIssued } }
+    }
+}
+
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HealthAlertSystemScreen(viewModel: HealthAlertViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val cases by viewModel.reportedCases.collectAsState()
+    val alerts by viewModel.activeAlerts.collectAsState()
+
+    var showReportCaseDialog by remember { mutableStateOf(false) }
+    var showUpdateStatusDialog by remember { mutableStateOf(false) }
+    var showCreateAlertDialog by remember { mutableStateOf(false) }
+    var selectedCaseForOps by remember { mutableStateOf<ReportedCase?>(null) }
+
+
+    if (showReportCaseDialog) {
+        ReportNewCaseDialog(
+            viewModel = viewModel,
+            onDismiss = { showReportCaseDialog = false }
+        )
+    }
+    if (showUpdateStatusDialog && selectedCaseForOps != null) {
+        UpdateCaseStatusDialog(
+            case = selectedCaseForOps!!,
+            viewModel = viewModel,
+            onDismiss = { showUpdateStatusDialog = false; selectedCaseForOps = null }
+        )
+    }
+    if (showCreateAlertDialog && selectedCaseForOps != null) {
+        CreateAlertDialog(
+            case = selectedCaseForOps!!,
+            viewModel = viewModel,
+            onDismiss = { showCreateAlertDialog = false; selectedCaseForOps = null }
+        )
+    }
+
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Health Alert System") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color(0xFFF06292)) // Pink
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { showReportCaseDialog = true }) {
+                Icon(Icons.Filled.Add, "Report New Case")
+            }
+        }
+    ) { paddingValues ->
+        LazyColumn(modifier = Modifier.padding(paddingValues).padding(16.dp)) {
+            item { SectionTitle("Active Health Alerts (${alerts.size})") }
+            if(alerts.isEmpty()) item { EmptyState("No active health alerts.")}
+            items(alerts, key = { it.alertId }) { alert -> ActiveAlertCard(alert) }
+
+            item { SectionTitle("Recently Reported Cases (${cases.size})") }
+            if(cases.isEmpty()) item { EmptyState("No cases reported yet.")}
+            items(cases, key = { it.caseId }) { case ->
+                ReportedCaseCard(case,
+                    onUpdateStatus = { selectedCaseForOps = it; showUpdateStatusDialog = true },
+                    onCreateAlert = { selectedCaseForOps = it; showCreateAlertDialog = true }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun SectionTitle(title: String) {
+    Text(title, style = MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(top = 16.dp, bottom = 8.dp))
+}
+@Composable
+fun EmptyState(message: String) {
+    Text(message, modifier = Modifier.padding(vertical = 8.dp).fillMaxWidth(), textAlign = androidx.compose.ui.text.style.TextAlign.Center)
+}
+
+
+@Composable
+fun ActiveAlertCard(alert: HealthAlert) {
+    Card(Modifier.fillMaxWidth().padding(vertical = 4.dp), elevation = CardDefaults.cardElevation(2.dp)) {
+        Column(Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text("ALERT: ${alert.diseaseName} (${alert.severity})", style = MaterialTheme.typography.titleMedium, color = if(alert.severity in listOf("High", "Critical")) Color.Red else MaterialTheme.colorScheme.onSurface)
+            Text("Location: ${alert.locationSummary}", style = MaterialTheme.typography.bodyMedium)
+            Text(alert.alertMessage, style = MaterialTheme.typography.bodyMedium)
+            Text("Issued: ${alert.getFormattedDateIssued()}", style = MaterialTheme.typography.bodySmall)
+            Text("Target: ${alert.targetAudience}", style = MaterialTheme.typography.bodySmall)
+            TextButton(onClick = { /* Open link */ }) { Text("More Info: ${alert.preventativeMeasuresLink}")}
+        }
+    }
+}
+
+@Composable
+fun ReportedCaseCard(case: ReportedCase, onUpdateStatus: () -> Unit, onCreateAlert: () -> Unit) {
+    Card(Modifier.fillMaxWidth().padding(vertical = 4.dp), elevation = CardDefaults.cardElevation(2.dp)) {
+        Column(Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text("${case.diseaseName} at ${case.location}", style = MaterialTheme.typography.titleMedium)
+            Text("Case ID: ${case.caseId}", style = MaterialTheme.typography.bodySmall)
+            Text("Status: ${case.status} (${case.severity})", fontWeight = FontWeight.Bold)
+            Text("Reported: ${case.getFormattedDateReported()} by ${case.sourceOfReport}")
+            Text("Species: ${case.affectedSpecies.joinToString()}, Confirmed: ${case.numberOfConfirmedCases}, Suspected: ${case.numberOfSuspectedCases}")
+            Text("Updates:", style = MaterialTheme.typography.labelMedium)
+            case.updates.takeLast(2).forEach { update ->
+                Text("- ${update.note} (${update.getFormattedTimestamp()}) ${update.updatedBy?.let{"by $it"} ?:""}", style = MaterialTheme.typography.bodySmall)
+            }
+            Row(Modifier.fillMaxWidth().padding(top=8.dp), horizontalArrangement = Arrangement.End, verticalAlignment = Alignment.CenterVertically) {
+                TextButton(onClick = onUpdateStatus) { Text("Update Status") }
+                Spacer(Modifier.width(8.dp))
+                if (case.severity in listOf("High", "Critical") && case.status !in listOf("resolved", "contained")) {
+                     Button(onClick = onCreateAlert, elevation = ButtonDefaults.buttonElevation(defaultElevation = 2.dp)) {
+                        Icon(Icons.Default.NotificationsActive, contentDescription = "Create Alert", modifier = Modifier.size(18.dp))
+                        Spacer(Modifier.width(4.dp))
+                        Text("Create Alert")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ReportNewCaseDialog(viewModel: HealthAlertViewModel, onDismiss: () -> Unit) {
+    var disease by remember { mutableStateOf(viewModel.knownDiseases.first()) }
+    var location by remember { mutableStateOf("") }
+    var lat by remember { mutableStateOf("") }
+    var lon by remember { mutableStateOf("") }
+    var radius by remember { mutableStateOf("10") }
+    var confirmed by remember { mutableStateOf("0") }
+    var suspected by remember { mutableStateOf("1") }
+    var selectedSpecies by remember { mutableStateOf(emptyList<String>()) } // For multi-select potentially
+    var severity by remember { mutableStateOf(viewModel.severities.first()) }
+    var source by remember { mutableStateOf("") }
+    var notes by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Report New Health Case") },
+        text = {
+            LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) { // Use LazyColumn if many fields
+                item { OutlinedTextField(value = disease, onValueChange = { disease = it }, label = { Text("Disease Name") }) } // Consider ExposedDropdownMenuBox
+                item { OutlinedTextField(value = location, onValueChange = { location = it }, label = { Text("Location (e.g., City, Farm ID)") }) }
+                item { Row {
+                    OutlinedTextField(value = lat, onValueChange = { lat = it.filter{c->c.isDigit()||c=='.'||c=='-'} }, label = { Text("Latitude") }, modifier = Modifier.weight(1f))
+                    Spacer(Modifier.width(8.dp))
+                    OutlinedTextField(value = lon, onValueChange = { lon = it.filter{c->c.isDigit()||c=='.'||c=='-'} }, label = { Text("Longitude") }, modifier = Modifier.weight(1f))
+                }}
+                item { OutlinedTextField(value = radius, onValueChange = { radius = it.filter{c->c.isDigit()||c=='.'} }, label = { Text("Affected Radius (km)") }, keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)) }
+                item { Row {
+                    OutlinedTextField(value = confirmed, onValueChange = { confirmed = it.filter{c->c.isDigit()} }, label = { Text("Confirmed Cases") }, keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number), modifier = Modifier.weight(1f))
+                    Spacer(Modifier.width(8.dp))
+                    OutlinedTextField(value = suspected, onValueChange = { suspected = it.filter{c->c.isDigit()} }, label = { Text("Suspected Cases") }, keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number), modifier = Modifier.weight(1f))
+                }}
+                // Species selection could be more complex (e.g., multi-select checkboxes)
+                item { OutlinedTextField(value = selectedSpecies.joinToString(), onValueChange = { selectedSpecies = it.split(",").map(String::trim).filter(String::isNotBlank) }, label = { Text("Affected Species (comma-sep)") }) }
+                item { ExposedDropdownMenuForOptions(label = "Severity", options = viewModel.severities, selectedOption = severity, onOptionSelected = { severity = it }) }
+                item { OutlinedTextField(value = source, onValueChange = { source = it }, label = { Text("Source of Report") }) }
+                item { OutlinedTextField(value = notes, onValueChange = { notes = it }, label = { Text("Initial Notes") }, maxLines = 3) }
+            }
+        },
+        confirmButton = { Button(onClick = {
+            viewModel.reportNewCase(disease, location, lat.toDoubleOrNull()?:0.0, lon.toDoubleOrNull()?:0.0, radius.toDoubleOrNull()?:10.0, confirmed.toIntOrNull()?:0, suspected.toIntOrNull()?:1, selectedSpecies, severity, source, notes, "user_android")
+            onDismiss()
+        }) { Text("Report Case") } },
+        dismissButton = { Button(onClick = onDismiss) { Text("Cancel") } }
+    )
+}
+
+@Composable
+fun UpdateCaseStatusDialog(case: ReportedCase, viewModel: HealthAlertViewModel, onDismiss: () -> Unit) {
+    var newStatus by remember { mutableStateOf(case.status) }
+    var notes by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Update Status for Case: ${case.caseId.take(8)}...")},
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text("Current Status: ${case.status}")
+                ExposedDropdownMenuForOptions(label = "New Status", options = viewModel.caseStatuses, selectedOption = newStatus, onOptionSelected = {newStatus = it})
+                OutlinedTextField(value = notes, onValueChange = {notes = it}, label = { Text("Update Notes")})
+            }
+        },
+        confirmButton = { Button(onClick = {
+            viewModel.updateCaseStatus(case.caseId, newStatus, notes, "admin_android")
+            onDismiss()
+        }) {Text("Update")} },
+        dismissButton = { Button(onClick = onDismiss) {Text("Cancel")} }
+    )
+}
+
+@Composable
+fun CreateAlertDialog(case: ReportedCase, viewModel: HealthAlertViewModel, onDismiss: () -> Unit) {
+    var customMessage by remember { mutableStateOf("") }
+     AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Create Alert for Case: ${case.caseId.take(8)}...")},
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text("Disease: ${case.diseaseName}, Severity: ${case.severity}")
+                OutlinedTextField(value = customMessage, onValueChange = {customMessage = it}, label = { Text("Custom Alert Message (Optional)")}, placeholder = {Text("Default message will be used if empty.")})
+            }
+        },
+        confirmButton = { Button(onClick = {
+            viewModel.createAlertFromCase(case.caseId, customMessage.ifBlank { null }, "admin_android")
+            onDismiss()
+        }) {Text("Create Alert")} },
+        dismissButton = { Button(onClick = onDismiss) {Text("Cancel")} }
+    )
+}
+
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ExposedDropdownMenuForOptions(
+    label: String,
+    options: List<String>,
+    selectedOption: String,
+    onOptionSelected: (String) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = !expanded }
+    ) {
+        OutlinedTextField(
+            value = selectedOption,
+            onValueChange = {}, readOnly = true,
+            label = { Text(label) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier.menuAnchor().fillMaxWidth()
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            options.forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(option) },
+                    onClick = {
+                        onOptionSelected(option)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+
+@Preview(showBackground = true, heightDp = 1200)
+@Composable
+fun PreviewHealthAlertSystemScreen() {
+    MaterialTheme {
+        HealthAlertSystemScreen(viewModel = HealthAlertViewModel())
+    }
+}

--- a/app/src/main/java/com/example/rooster/veterinary/patienthistory/PatientHistoryScreen.kt
+++ b/app/src/main/java/com/example/rooster/veterinary/patienthistory/PatientHistoryScreen.kt
@@ -1,0 +1,367 @@
+package com.example.rooster.veterinary.patienthistory
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import kotlin.random.Random
+
+// --- Data Classes ---
+data class MedicationPrescribed(
+    val medication: String,
+    val dosage: String,
+    val duration: String
+)
+
+data class VaccinationGiven(
+    val vaccineName: String,
+    val batchNumber: String,
+    val nextDue: String? // ISO Date String
+)
+
+data class MedicalRecord(
+    val recordId: String,
+    val visitDate: Date,
+    val recordType: String, // check-up, vaccination, illness, injury, procedure
+    val attendingVetName: String,
+    val presentingComplaint: String,
+    val diagnosis: String,
+    val treatmentPlan: String,
+    val medicationsPrescribed: List<MedicationPrescribed> = emptyList(),
+    val vaccinationsGiven: List<VaccinationGiven> = emptyList(),
+    val weightKg: Double?,
+    val temperatureCelsius: Double?,
+    val notes: String,
+    val followUpNeeded: Boolean
+) {
+    fun getFormattedVisitDate(): String = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(visitDate)
+}
+
+data class PatientDetails(
+    val patientId: String,
+    val name: String,
+    val species: String,
+    val breed: String,
+    val dob: String, // ISO Date String
+    val ownerId: String,
+    val gender: String?,
+    val color: String? = null,
+    val microchipId: String? = null
+)
+
+data class PatientFullHistory(
+    val details: PatientDetails,
+    val records: List<MedicalRecord>
+)
+
+// --- ViewModel ---
+class PatientHistoryViewModel : ViewModel() {
+    private val _patientHistory = MutableStateFlow<PatientFullHistory?>(null)
+    val patientHistory: StateFlow<PatientFullHistory?> = _patientHistory
+
+    private var currentPatientId: String = "pet001" // Default patient to display
+
+    // Mock data for dropdowns in Add Record Dialog
+    val recordTypes = listOf("check_up", "vaccination", "illness", "injury", "procedure")
+    val commonVets = listOf("Dr. Alice Smith", "Dr. Bob Johnson", "Dr. Carol White", "Dr. Eve Foster")
+
+
+    init {
+        loadPatientData(currentPatientId)
+    }
+
+    fun loadPatientData(patientId: String) {
+        currentPatientId = patientId
+        // In a real app, this would fetch from a database or API
+        // For now, generate mock data for the requested patientId
+        _patientHistory.value = generateMockPatientFullHistory(patientId)
+    }
+
+    private fun generateMockPatientFullHistory(patientId: String): PatientFullHistory {
+        val details = PatientDetails( // Simplified for direct use
+            patientId = patientId,
+            name = when(patientId) {
+                "pet001" -> "Bessie"
+                "pet002" -> "Charlie"
+                "pet003" -> "Daisy"
+                else -> "Unknown Pet"
+            },
+            species = if (patientId == "pet002") "Dog" else "Cow",
+            breed = if (patientId == "pet002") "Labrador" else "Holstein",
+            dob = if (patientId == "pet002") "2020-07-22" else "2018-03-15",
+            ownerId = "farmer${Random.nextInt(1,5).toString().padStart(3,'0')}",
+            gender = if (Random.nextBoolean()) "Female" else "Male"
+        )
+
+        val records = mutableListOf<MedicalRecord>()
+        val numRecords = Random.nextInt(1, 5)
+        for (i in 0 until numRecords) {
+            val visitDate = Date(System.currentTimeMillis() - Random.nextLong(10, 730) * 86400000L)
+            records.add(
+                MedicalRecord(
+                    recordId = "rec_${visitDate.time}_$i",
+                    visitDate = visitDate,
+                    recordType = recordTypes.random(),
+                    attendingVetName = commonVets.random(),
+                    presentingComplaint = "Symptom $i",
+                    diagnosis = "Diagnosis $i",
+                    treatmentPlan = "Treatment plan $i",
+                    medicationsPrescribed = if (Random.nextBoolean()) listOf(MedicationPrescribed("Med A", "1 tab BID", "7 days")) else emptyList(),
+                    vaccinationsGiven = if (Random.nextBoolean()) listOf(VaccinationGiven("Vaccine X", "B123", "2024-12-31")) else emptyList(),
+                    weightKg = Random.nextDouble(5.0, (if(details.species == "Cow") 600.0 else 50.0)),
+                    temperatureCelsius = Random.nextDouble(37.5, 39.5),
+                    notes = "Notes for visit $i.",
+                    followUpNeeded = Random.nextBoolean()
+                )
+            )
+        }
+        return PatientFullHistory(details, records.sortedByDescending { it.visitDate })
+    }
+
+    fun addMedicalRecord(patientId: String, record: MedicalRecord) {
+        _patientHistory.update { currentHistory ->
+            currentHistory?.copy(records = (listOf(record) + currentHistory.records).sortedByDescending { it.visitDate })
+        }
+        // In a real app, persist this record.
+    }
+}
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PatientHistoryScreen(viewModel: PatientHistoryViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val patientHistory by viewModel.patientHistory.collectAsState()
+
+    // State for Add Record Dialog
+    var showAddRecordDialog by remember { mutableStateOf(false) }
+
+    if (showAddRecordDialog && patientHistory != null) {
+        AddMedicalRecordDialog(
+            patientId = patientHistory!!.details.patientId,
+            viewModel = viewModel,
+            onDismiss = { showAddRecordDialog = false }
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Patient History: ${patientHistory?.details?.name ?: "Loading..."}") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color(0xFF795548)) // Brown
+            )
+        },
+        floatingActionButton = {
+            if (patientHistory != null) { // Show FAB only when patient data is loaded
+                FloatingActionButton(onClick = { showAddRecordDialog = true }) {
+                    Icon(Icons.Filled.Add, "Add Medical Record")
+                }
+            }
+        }
+    ) { paddingValues ->
+        patientHistory?.let { history ->
+            LazyColumn(modifier = Modifier.padding(paddingValues).padding(16.dp)) {
+                item { PatientDetailsCard(history.details) }
+                item {
+                    Text(
+                        "Medical Records (${history.records.size})",
+                        style = MaterialTheme.typography.headlineSmall,
+                        modifier = Modifier.padding(top = 16.dp, bottom = 8.dp)
+                    )
+                }
+                if (history.records.isEmpty()) {
+                    item { Text("No medical records found for this patient.") }
+                } else {
+                    items(history.records, key = { it.recordId }) { record ->
+                        MedicalRecordCard(record)
+                    }
+                }
+            }
+        } ?: Box(modifier = Modifier.fillMaxSize().padding(paddingValues), contentAlignment = Alignment.Center) {
+            // Show a loading indicator or allow patient selection
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text("Enter Patient ID to load history:")
+                var patientIdInput by remember { mutableStateOf("pet001") }
+                OutlinedTextField(
+                    value = patientIdInput,
+                    onValueChange = { patientIdInput = it },
+                    label = { Text("Patient ID") },
+                    modifier = Modifier.padding(vertical = 8.dp)
+                )
+                Button(onClick = { viewModel.loadPatientData(patientIdInput.trim()) }) {
+                    Text("Load Patient")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun PatientDetailsCard(details: PatientDetails) {
+    Card(Modifier.fillMaxWidth().padding(bottom = 16.dp), elevation = CardDefaults.cardElevation(2.dp)) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text("Patient: ${details.name} (ID: ${details.patientId})", style = MaterialTheme.typography.titleLarge)
+            Text("Species: ${details.species}, Breed: ${details.breed}")
+            Text("DOB: ${details.dob}, Gender: ${details.gender ?: "N/A"}")
+            Text("Owner ID: ${details.ownerId}")
+            details.color?.let { Text("Color: $it") }
+            details.microchipId?.let { Text("Microchip: $it") }
+        }
+    }
+}
+
+@Composable
+fun MedicalRecordCard(record: MedicalRecord) {
+    val df = remember { DecimalFormat("#0.0") }
+    Card(Modifier.fillMaxWidth().padding(vertical = 6.dp), elevation = CardDefaults.cardElevation(2.dp)) {
+        Column(Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text("Visit: ${record.getFormattedVisitDate()} - ${record.recordType.replaceFirstChar { it.titlecase() }}", style = MaterialTheme.typography.titleMedium)
+            Text("Vet: ${record.attendingVetName}", style = MaterialTheme.typography.bodySmall)
+            Divider(modifier = Modifier.padding(vertical = 4.dp))
+            Text("Complaint: ${record.presentingComplaint}")
+            Text("Diagnosis: ${record.diagnosis}", fontWeight = FontWeight.Bold)
+            Text("Treatment: ${record.treatmentPlan}")
+            if (record.medicationsPrescribed.isNotEmpty()) {
+                Text("Medications:", style = MaterialTheme.typography.labelMedium, modifier = Modifier.padding(top=4.dp))
+                record.medicationsPrescribed.forEach { med ->
+                    Text("  - ${med.medication} (${med.dosage}, ${med.duration})")
+                }
+            }
+            if (record.vaccinationsGiven.isNotEmpty()) {
+                Text("Vaccinations:", style = MaterialTheme.typography.labelMedium, modifier = Modifier.padding(top=4.dp))
+                record.vaccinationsGiven.forEach { vacc ->
+                    Text("  - ${vacc.vaccineName} (Batch: ${vacc.batchNumber}, Next Due: ${vacc.nextDue ?: "N/A"})")
+                }
+            }
+            Row(modifier = Modifier.padding(top = 4.dp)) {
+                record.weightKg?.let { Text("Weight: ${df.format(it)} kg", modifier = Modifier.weight(1f)) }
+                record.temperatureCelsius?.let { Text("Temp: ${df.format(it)} °C", modifier = Modifier.weight(1f)) }
+            }
+            Text("Notes: ${record.notes}")
+            Text("Follow-up Needed: ${if (record.followUpNeeded) "Yes" else "No"}")
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddMedicalRecordDialog(patientId: String, viewModel: PatientHistoryViewModel, onDismiss: () -> Unit) {
+    var visitDate by remember { mutableStateOf(SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(Date())) }
+    var recordType by remember { mutableStateOf(viewModel.recordTypes.first()) }
+    var attendingVet by remember { mutableStateOf(viewModel.commonVets.first()) }
+    var complaint by remember { mutableStateOf("") }
+    var diagnosis by remember { mutableStateOf("") }
+    var treatment by remember { mutableStateOf("") }
+    var notes by remember { mutableStateOf("") }
+    var weight by remember { mutableStateOf("") }
+    var temp by remember { mutableStateOf("") }
+    var followUp by remember { mutableStateOf(false) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Add Medical Record for $patientId") },
+        text = {
+            LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) { // For scrollability if form is long
+                item { OutlinedTextField(value = visitDate, onValueChange = { visitDate = it }, label = { Text("Visit Date (YYYY-MM-DD)") }) }
+                item { ExposedDropdownMenuForOptions(label = "Record Type", options = viewModel.recordTypes, selectedOption = recordType, onOptionSelected = { recordType = it }) }
+                item { ExposedDropdownMenuForOptions(label = "Attending Vet", options = viewModel.commonVets, selectedOption = attendingVet, onOptionSelected = { attendingVet = it }) }
+                item { OutlinedTextField(value = complaint, onValueChange = { complaint = it }, label = { Text("Presenting Complaint") }) }
+                item { OutlinedTextField(value = diagnosis, onValueChange = { diagnosis = it }, label = { Text("Diagnosis") }) }
+                item { OutlinedTextField(value = treatment, onValueChange = { treatment = it }, label = { Text("Treatment Plan") }) }
+                item { OutlinedTextField(value = weight, onValueChange = { weight = it.filter{c->c.isDigit()||c=='.'} }, label = { Text("Weight (kg)") }, keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)) }
+                item { OutlinedTextField(value = temp, onValueChange = { temp = it.filter{c->c.isDigit()||c=='.'} }, label = { Text("Temperature (°C)") }, keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)) }
+                item { OutlinedTextField(value = notes, onValueChange = { notes = it }, label = { Text("Notes") }, maxLines = 3) }
+                item { Row(verticalAlignment = Alignment.CenterVertically) {
+                    Checkbox(checked = followUp, onCheckedChange = { followUp = it })
+                    Text("Follow-up Needed")
+                }}
+            }
+        },
+        confirmButton = {
+            Button(onClick = {
+                val dateParsed = try { SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).parse(visitDate) } catch (e: Exception) { Date() }
+                val newRecord = MedicalRecord(
+                    recordId = "rec_${System.currentTimeMillis()}",
+                    visitDate = dateParsed ?: Date(),
+                    recordType = recordType,
+                    attendingVetName = attendingVet,
+                    presentingComplaint = complaint,
+                    diagnosis = diagnosis,
+                    treatmentPlan = treatment,
+                    notes = notes,
+                    weightKg = weight.toDoubleOrNull(),
+                    temperatureCelsius = temp.toDoubleOrNull(),
+                    followUpNeeded = followUp
+                    // Medications and Vaccinations can be added via a more complex UI later
+                )
+                viewModel.addMedicalRecord(patientId, newRecord)
+                onDismiss()
+            }) { Text("Add Record") }
+        },
+        dismissButton = { Button(onClick = onDismiss) { Text("Cancel") } }
+    )
+}
+
+// Re-using ExposedDropdownMenuForOptions from HealthAlertSystemScreen, assuming it's accessible
+// If not, it should be defined here or in a shared UI module.
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ExposedDropdownMenuForOptions( // Copied from HealthAlertSystemScreen for standalone preview
+    label: String,
+    options: List<String>,
+    selectedOption: String,
+    onOptionSelected: (String) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = !expanded }
+    ) {
+        OutlinedTextField(
+            value = selectedOption,
+            onValueChange = {}, readOnly = true,
+            label = { Text(label) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier.menuAnchor().fillMaxWidth()
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            options.forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(option) },
+                    onClick = {
+                        onOptionSelected(option)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+
+@Preview(showBackground = true, heightDp = 1000)
+@Composable
+fun PreviewPatientHistoryScreen() {
+    MaterialTheme {
+        PatientHistoryScreen(viewModel = PatientHistoryViewModel())
+    }
+}

--- a/app/src/main/java/com/example/rooster/veterinary/prescriptions/PrescriptionManagementScreen.kt
+++ b/app/src/main/java/com/example/rooster/veterinary/prescriptions/PrescriptionManagementScreen.kt
@@ -1,0 +1,340 @@
+package com.example.rooster.veterinary.prescriptions
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import kotlin.random.Random
+
+// --- Data Classes ---
+data class MedicationCatalogItem(
+    val name: String,
+    val unit: String,
+    val requiresVetAuth: Boolean
+)
+
+data class Prescription(
+    val prescriptionId: String,
+    val vetId: String,
+    val vetName: String,
+    val patientId: String,
+    val patientName: String,
+    val userId: String, // Owner
+    val dateIssued: Date,
+    val medicationName: String,
+    var dosage: String,
+    var frequency: String,
+    var duration: String,
+    var quantityDispensed: String? = null,
+    var dispensingPharmacyId: String? = null,
+    var instructions: String,
+    var refillsAllowed: Int,
+    var refillsRemaining: Int,
+    var status: String, // issued, dispensed, cancelled, expired, recommended
+    var notes: String?,
+    var dateDispensed: Date? = null,
+    var lastUpdatedBy: String? = null,
+    var lastUpdatedAt: Date? = null
+) {
+    fun getFormattedDate(date: Date?): String =
+        date?.let { SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(it) } ?: "N/A"
+}
+
+// --- ViewModel ---
+class PrescriptionViewModel : ViewModel() {
+    private val _prescriptions = MutableStateFlow<List<Prescription>>(emptyList())
+    val prescriptions: StateFlow<List<Prescription>> = _prescriptions
+
+    val medicationCatalog = listOf(
+        MedicationCatalogItem("Amoxicillin 250mg tablets", "tablet", true),
+        MedicationCatalogItem("Meloxicam 1mg/ml Oral Suspension", "ml", true),
+        MedicationCatalogItem("Ivermectin Pour-On", "ml", true),
+        MedicationCatalogItem("Saline Eye Wash", "bottle", false),
+        MedicationCatalogItem("Medicated Shampoo", "bottle", false),
+        MedicationCatalogItem("Fenbendazole Granules 22.2%", "gram", true)
+    )
+    val knownVetIds = (1..3).map { "vet${it.toString().padStart(3,'0')}" }
+    val knownPatientIds = (1..5).map { "pet${it.toString().padStart(3,'0')}" }
+    val knownUserIds = (1..5).map { "farmer${it.toString().padStart(3,'0')}" }
+    val prescriptionStatuses = listOf("issued", "dispensed", "cancelled", "expired", "recommended")
+
+
+    init {
+        loadMockPrescriptions()
+    }
+
+    private fun loadMockPrescriptions(count: Int = 5) {
+        val now = Date()
+        val tempPrescriptions = mutableListOf<Prescription>()
+        for (i in 0 until count) {
+            val medInfo = medicationCatalog.random()
+            val issueDate = Date(now.time - Random.nextLong(0, 90 * 86400000L))
+            val status = if (medInfo.requiresVetAuth) listOf("issued", "dispensed", "cancelled").random() else listOf("recommended", "dispensed").random()
+            val p = Prescription(
+                prescriptionId = "rx_${issueDate.time}_$i",
+                vetId = knownVetIds.random(),
+                vetName = "Dr. Mock Vet", // Simplified
+                patientId = knownPatientIds.random(),
+                patientName = "Mock Patient", // Simplified
+                userId = knownUserIds.random(),
+                dateIssued = issueDate,
+                medicationName = medInfo.name,
+                dosage = "${Random.nextInt(1, 3)} ${medInfo.unit}(s)",
+                frequency = listOf("Once daily", "Twice daily", "As needed").random(),
+                duration = if (medInfo.requiresVetAuth) "${Random.nextInt(3,14)} days" else "Until symptoms resolve",
+                instructions = "Follow directions carefully.",
+                refillsAllowed = if (medInfo.requiresVetAuth) Random.nextInt(0, 3) else 0,
+                refillsRemaining = 0, // Will be set
+                status = status,
+                notes = if (medInfo.requiresVetAuth) "Ensure full course." else "OTC recommendation."
+            )
+            p.refillsRemaining = p.refillsAllowed
+            if (status == "dispensed") {
+                p.quantityDispensed = "${Random.nextInt(10,50)} ${medInfo.unit}(s)"
+                p.dispensingPharmacyId = "pharm${Random.nextInt(1,3)}"
+                p.dateDispensed = Date(issueDate.time + Random.nextLong(0, 2 * 86400000L))
+                if(p.refillsRemaining > 0) p.refillsRemaining--
+            }
+            tempPrescriptions.add(p)
+        }
+        _prescriptions.value = tempPrescriptions.sortedByDescending { it.dateIssued }
+    }
+
+    fun createPrescription(vetId: String, patientId: String, userId: String, medName: String, dosage: String, freq: String, duration: String, instr: String, refills: Int, notes: String?) {
+        val medInfo = medicationCatalog.find { it.name == medName } ?: return // Should not happen if UI uses catalog
+        val newRx = Prescription(
+            prescriptionId = "rx_${Date().time}_${Random.nextInt(1000)}",
+            vetId = vetId, vetName = "Dr. Current User", patientId = patientId, patientName = "Patient $patientId", userId = userId,
+            dateIssued = Date(), medicationName = medName, dosage = dosage, frequency = freq, duration = duration,
+            instructions = instr, refillsAllowed = refills, refillsRemaining = refills, status = "issued", notes = notes
+        )
+        _prescriptions.update { (listOf(newRx) + it).sortedByDescending { rx -> rx.dateIssued } }
+    }
+
+    fun updatePrescriptionStatus(rxId: String, newStatus: String, updatedBy: String, qtyDispensed: String? = null, pharmacyId: String? = null) {
+        _prescriptions.update { list ->
+            list.map {
+                if (it.prescriptionId == rxId) {
+                    it.copy(
+                        status = newStatus,
+                        lastUpdatedAt = Date(),
+                        lastUpdatedBy = updatedBy,
+                        quantityDispensed = if (newStatus == "dispensed") qtyDispensed ?: it.quantityDispensed else it.quantityDispensed,
+                        dispensingPharmacyId = if (newStatus == "dispensed") pharmacyId ?: it.dispensingPharmacyId else it.dispensingPharmacyId,
+                        dateDispensed = if (newStatus == "dispensed") Date() else it.dateDispensed,
+                        refillsRemaining = if (newStatus == "dispensed" && it.refillsRemaining > 0) it.refillsRemaining -1 else it.refillsRemaining
+                    )
+                } else it
+            }
+        }
+    }
+}
+
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PrescriptionManagementScreen(viewModel: PrescriptionViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val prescriptions by viewModel.prescriptions.collectAsState()
+    var showCreateDialog by remember { mutableStateOf(false) }
+    var showUpdateStatusDialog by remember { mutableStateOf(false) }
+    var selectedPrescription by remember { mutableStateOf<Prescription?>(null) }
+
+    if (showCreateDialog) {
+        CreatePrescriptionDialog(viewModel = viewModel, onDismiss = { showCreateDialog = false })
+    }
+    if (showUpdateStatusDialog && selectedPrescription != null) {
+        UpdatePrescriptionStatusDialog(
+            prescription = selectedPrescription!!,
+            viewModel = viewModel,
+            onDismiss = { showUpdateStatusDialog = false; selectedPrescription = null }
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Prescription Management") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color(0xFF26A69A)) // Teal
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { showCreateDialog = true }) {
+                Icon(Icons.Filled.Add, "Create New Prescription")
+            }
+        }
+    ) { paddingValues ->
+        LazyColumn(modifier = Modifier.padding(paddingValues).padding(16.dp)) {
+            if (prescriptions.isEmpty()) {
+                item { Text("No prescriptions found.") }
+            } else {
+                items(prescriptions, key = { it.prescriptionId }) { rx ->
+                    PrescriptionCard(rx) {
+                        selectedPrescription = rx
+                        showUpdateStatusDialog = true
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun PrescriptionCard(rx: Prescription, onCardClick: () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp).clickable(onClick = onCardClick), elevation = CardDefaults.cardElevation(2.dp)) {
+        Column(Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text("${rx.medicationName} (ID: ${rx.prescriptionId.takeLast(6)})", style = MaterialTheme.typography.titleMedium)
+            Text("Patient: ${rx.patientName} (ID: ${rx.patientId}) - Owner: ${rx.userId}")
+            Text("Vet: ${rx.vetName} (ID: ${rx.vetId})")
+            Text("Issued: ${rx.getFormattedDate(rx.dateIssued)}")
+            Text("Dosage: ${rx.dosage}, ${rx.frequency} for ${rx.duration}")
+            Text("Instructions: ${rx.instructions}")
+            Text("Refills: ${rx.refillsRemaining}/${rx.refillsAllowed}")
+            Text("Status: ${rx.status}", color = when(rx.status){
+                "issued" -> Color.Blue
+                "dispensed" -> Color.Green
+                "cancelled", "expired" -> Color.Red
+                else -> Color.DarkGray
+            })
+            rx.notes?.let { Text("Notes: $it") }
+            if (rx.status == "dispensed") {
+                Text("Dispensed: ${rx.quantityDispensed ?: ""} by ${rx.dispensingPharmacyId ?: ""} on ${rx.getFormattedDate(rx.dateDispensed)}")
+            }
+            rx.lastUpdatedAt?.let { Text("Last Update: ${rx.getFormattedDate(it)} by ${rx.lastUpdatedBy ?: ""}", style = MaterialTheme.typography.bodySmall) }
+        }
+    }
+}
+
+@Composable
+fun CreatePrescriptionDialog(viewModel: PrescriptionViewModel, onDismiss: () -> Unit) {
+    // Basic fields for simplicity, can be expanded
+    var patientId by remember { mutableStateOf(viewModel.knownPatientIds.first()) }
+    var medicationName by remember { mutableStateOf(viewModel.medicationCatalog.first().name) }
+    var dosage by remember { mutableStateOf("") }
+    var frequency by remember { mutableStateOf("") }
+    var duration by remember { mutableStateOf("") }
+    var instructions by remember { mutableStateOf("") }
+    var refills by remember { mutableStateOf("0") }
+    var notes by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Create New Prescription") },
+        text = {
+            LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                item { ExposedDropdownMenuForOptions(label = "Patient ID", options = viewModel.knownPatientIds, selectedOption = patientId, onOptionSelected = { patientId = it }) }
+                item { ExposedDropdownMenuForOptions(label = "Medication", options = viewModel.medicationCatalog.map { it.name }, selectedOption = medicationName, onOptionSelected = { medicationName = it }) }
+                item { OutlinedTextField(value = dosage, onValueChange = { dosage = it }, label = { Text("Dosage (e.g., 1 tablet)") }) }
+                item { OutlinedTextField(value = frequency, onValueChange = { frequency = it }, label = { Text("Frequency (e.g., Twice daily)") }) }
+                item { OutlinedTextField(value = duration, onValueChange = { duration = it }, label = { Text("Duration (e.g., 7 days)") }) }
+                item { OutlinedTextField(value = instructions, onValueChange = { instructions = it }, label = { Text("Instructions") }) }
+                item { OutlinedTextField(value = refills, onValueChange = { refills = it.filter(Char::isDigit) }, label = { Text("Refills Allowed") }, keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)) }
+                item { OutlinedTextField(value = notes, onValueChange = { notes = it }, label = { Text("Notes (Optional)") }) }
+            }
+        },
+        confirmButton = {
+            Button(onClick = {
+                viewModel.createPrescription(
+                    vetId = "vet_current_user", // Placeholder
+                    patientId = patientId,
+                    userId = "farmer_current_user", // Placeholder
+                    medName = medicationName,
+                    dosage = dosage, freq = frequency, duration = duration, instr = instructions,
+                    refills = refills.toIntOrNull() ?: 0, notes = notes.ifBlank { null }
+                )
+                onDismiss()
+            }) { Text("Create") }
+        },
+        dismissButton = { Button(onClick = onDismiss) { Text("Cancel") } }
+    )
+}
+
+@Composable
+fun UpdatePrescriptionStatusDialog(prescription: Prescription, viewModel: PrescriptionViewModel, onDismiss: () -> Unit) {
+    var newStatus by remember { mutableStateOf(prescription.status) }
+    var qtyDispensed by remember { mutableStateOf(prescription.quantityDispensed ?: "") }
+    var pharmacyId by remember { mutableStateOf(prescription.dispensingPharmacyId ?: "") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Update Rx: ${prescription.prescriptionId.takeLast(6)}") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text("Medication: ${prescription.medicationName}")
+                ExposedDropdownMenuForOptions(label = "New Status", options = viewModel.prescriptionStatuses, selectedOption = newStatus, onOptionSelected = {newStatus = it})
+                if (newStatus == "dispensed") {
+                    OutlinedTextField(value = qtyDispensed, onValueChange = {qtyDispensed = it}, label = {Text("Quantity Dispensed")})
+                    OutlinedTextField(value = pharmacyId, onValueChange = {pharmacyId = it}, label = {Text("Dispensing Pharmacy ID")})
+                }
+            }
+        },
+        confirmButton = { Button(onClick = {
+            viewModel.updatePrescriptionStatus(prescription.prescriptionId, newStatus, "admin_compose", if(newStatus == "dispensed") qtyDispensed else null, if(newStatus == "dispensed") pharmacyId else null)
+            onDismiss()
+        }) {Text("Update Status")} },
+        dismissButton = { Button(onClick = onDismiss) {Text("Cancel")} }
+    )
+}
+
+// Re-using ExposedDropdownMenuForOptions, assuming it's accessible
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ExposedDropdownMenuForOptions( // Copied for standalone preview if needed
+    label: String,
+    options: List<String>,
+    selectedOption: String,
+    onOptionSelected: (String) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = !expanded }
+    ) {
+        OutlinedTextField(
+            value = selectedOption,
+            onValueChange = {}, readOnly = true,
+            label = { Text(label) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier.menuAnchor().fillMaxWidth()
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            options.forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(option) },
+                    onClick = {
+                        onOptionSelected(option)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, heightDp = 800)
+@Composable
+fun PreviewPrescriptionManagementScreen() {
+    MaterialTheme {
+        PrescriptionManagementScreen(viewModel = PrescriptionViewModel())
+    }
+}

--- a/app/src/main/java/com/example/rooster/veterinary/telemedicine/TelemedicineScreen.kt
+++ b/app/src/main/java/com/example/rooster/veterinary/telemedicine/TelemedicineScreen.kt
@@ -1,0 +1,348 @@
+package com.example.rooster.veterinary.telemedicine
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import kotlin.random.Random
+
+// --- Data Classes ---
+data class ChatMessage(
+    val senderId: String,
+    val message: String,
+    val timestamp: Date
+) {
+    fun getFormattedTimestamp(): String = SimpleDateFormat("HH:mm:ss", Locale.getDefault()).format(timestamp)
+}
+
+data class SharedFile(
+    val filename: String,
+    val uploaderId: String,
+    val timestamp: Date,
+    val fileUrl: String
+) {
+     fun getFormattedTimestamp(): String = SimpleDateFormat("HH:mm:ss", Locale.getDefault()).format(timestamp)
+}
+
+data class TelemedicineSession(
+    val sessionId: String,
+    val vetId: String,
+    val userId: String,
+    val patientId: String,
+    val patientName: String,
+    val appointmentId: String? = null,
+    val startTime: Date,
+    var endTime: Date? = null,
+    var status: String, // initiating, connecting, active, ended, disconnected
+    var callQuality: String? = null,
+    val chatLog: MutableList<ChatMessage> = mutableListOf(),
+    val sharedFiles: MutableList<SharedFile> = mutableListOf(),
+    var sessionNotesVet: String = "",
+    val connectionUrl: String,
+    var endedBy: String? = null,
+    var durationMinutes: Double? = null
+) {
+    fun getFormattedTimestamp(date: Date?): String =
+        date?.let { SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(it) } ?: "N/A"
+}
+
+// --- ViewModel ---
+class TelemedicineViewModel : ViewModel() {
+    private val _activeSession = MutableStateFlow<TelemedicineSession?>(null)
+    val activeSession: StateFlow<TelemedicineSession?> = _activeSession
+
+    private val _sessionHistory = MutableStateFlow<List<TelemedicineSession>>(emptyList())
+    val sessionHistory: StateFlow<List<TelemedicineSession>> = _sessionHistory
+
+    private var callSimulationJob: Job? = null
+
+    // Mock data
+    val knownVetIds = (1..2).map { "vet${it.toString().padStart(3,'0')}" }
+    val knownUserIds = (1..3).map { "user${it.toString().padStart(3,'0')}" }
+    val patientNames = listOf("Bessie", "Charlie", "Max")
+    private val currentVetId = knownVetIds.first() // Assume this vet is using the app
+    private val currentUserId = knownUserIds.first() // For simulating user actions
+
+    fun initiateCall(vetId: String, userId: String, patientId: String, patientName: String) {
+        if (_activeSession.value != null && _activeSession.value?.status != "ended") {
+            // Prevent new call if one is active/pending
+            return
+        }
+        val sessionId = "telemed_${Date().time}_${Random.nextInt(1000)}"
+        val newSession = TelemedicineSession(
+            sessionId = sessionId, vetId = vetId, userId = userId, patientId = patientId, patientName = patientName,
+            startTime = Date(), status = "initiating", connectionUrl = "https://telemed.example.com/join/$sessionId"
+        )
+        _activeSession.value = newSession
+        simulateCallProgress(newSession)
+    }
+
+    private fun simulateCallProgress(session: TelemedicineSession) {
+        callSimulationJob?.cancel()
+        callSimulationJob = viewModelScope.launch {
+            delay(1000) // Initiating
+            _activeSession.update { it?.copy(status = "connecting") }
+            delay(1500) // Connecting
+            _activeSession.update { it?.copy(status = "active", callQuality = listOf("good", "fair").random()) }
+        }
+    }
+
+    fun sendChatMessage(senderId: String, message: String) {
+        _activeSession.update { session ->
+            session?.takeIf { it.status == "active" }?.apply {
+                chatLog.add(ChatMessage(senderId, message, Date()))
+            }?.let { return@update it.copy(chatLog = it.chatLog.toMutableList()) } // Force recomposition by creating new list
+            session // return original if no update
+        }
+    }
+
+    fun shareFile(uploaderId: String, filename: String) {
+         _activeSession.update { session ->
+            session?.takeIf { it.status == "active" }?.apply {
+                sharedFiles.add(SharedFile(filename, uploaderId, Date(), "https://files.example.com/$sessionId/$filename"))
+            }?.let { return@update it.copy(sharedFiles = it.sharedFiles.toMutableList()) }
+            session
+        }
+    }
+     fun updateVetNotes(notes: String) {
+        _activeSession.update { session ->
+            session?.takeIf { it.status == "active" && it.vetId == currentVetId }?.copy(sessionNotesVet = notes) ?: session
+        }
+    }
+
+
+    fun endCall(endedById: String) {
+        callSimulationJob?.cancel()
+        _activeSession.value?.let { session ->
+            val endedSession = session.copy(
+                status = "ended",
+                endTime = Date(),
+                endedBy = endedById,
+                durationMinutes = ((Date().time - session.startTime.time) / 60000.0)
+            )
+            _sessionHistory.update { listOf(endedSession) + it }
+            _activeSession.value = null // Clear active session
+        }
+    }
+}
+
+// --- Composable Screen ---
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TelemedicineScreen(viewModel: TelemedicineViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+    val activeSession by viewModel.activeSession.collectAsState()
+    val history by viewModel.sessionHistory.collectAsState()
+
+    // For new call dialog
+    var showInitiateCallDialog by remember { mutableStateOf(false) }
+
+    if (showInitiateCallDialog) {
+        InitiateCallDialog(viewModel = viewModel, onDismiss = { showInitiateCallDialog = false })
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Telemedicine") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color(0xFF03A9F4)) // Light Blue
+            )
+        },
+        floatingActionButton = {
+            if (activeSession == null) { // Show FAB only if no active call
+                FloatingActionButton(onClick = { showInitiateCallDialog = true }) {
+                    Icon(Icons.Filled.VideoCall, "Initiate New Call")
+                }
+            }
+        }
+    ) { paddingValues ->
+        Column(modifier = Modifier.padding(paddingValues).padding(16.dp)) {
+            activeSession?.let { session ->
+                ActiveCallScreen(session = session, viewModel = viewModel)
+            } ?: SessionHistoryScreen(history = history)
+        }
+    }
+}
+
+@Composable
+fun ActiveCallScreen(session: TelemedicineSession, viewModel: TelemedicineViewModel) {
+    var chatInput by remember { mutableStateOf("") }
+    var vetNotesInput by remember { mutableStateOf(session.sessionNotesVet) }
+
+    Column(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text("Active Call with ${session.patientName} (User: ${session.userId}, Vet: ${session.vetId})", style = MaterialTheme.typography.headlineSmall)
+        Text("Status: ${session.status}, Quality: ${session.callQuality ?: "N/A"}")
+        Text("URL: ${session.connectionUrl}")
+        Spacer(Modifier.height(8.dp))
+
+        // Chat Area (Simplified)
+        Text("Chat Log:", style = MaterialTheme.typography.titleMedium)
+        LazyColumn(modifier = Modifier.weight(1f).fillMaxWidth().padding(vertical = 4.dp).heightIn(max = 200.dp), reverseLayout = true) {
+            items(session.chatLog.reversed()) { msg -> Text("${msg.senderId} (${msg.getFormattedTimestamp()}): ${msg.message}") }
+        }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            OutlinedTextField(value = chatInput, onValueChange = { chatInput = it }, label = { Text("Send Message") }, modifier = Modifier.weight(1f))
+            IconButton(onClick = { if(chatInput.isNotBlank()) viewModel.sendChatMessage(viewModel.currentVetId, chatInput); chatInput = "" }) {
+                Icon(Icons.Filled.Send, "Send")
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+        // Vet Notes
+        OutlinedTextField(
+            value = vetNotesInput,
+            onValueChange = { vetNotesInput = it; viewModel.updateVetNotes(it) }, // Update ViewModel on change
+            label = { Text("Vet Session Notes") },
+            modifier = Modifier.fillMaxWidth(),
+            minLines = 3
+        )
+         Spacer(Modifier.height(8.dp))
+        // Actions
+        Row(horizontalArrangement = Arrangement.SpaceEvenly, modifier = Modifier.fillMaxWidth()) {
+            Button(onClick = { viewModel.shareFile(viewModel.currentVetId, "patient_image_${Random.nextInt(100)}.jpg") }) { Text("Share File") }
+            Button(onClick = { viewModel.endCall(viewModel.currentVetId) }, colors = ButtonDefaults.buttonColors(containerColor = Color.Red)) { Text("End Call") }
+        }
+        if(session.sharedFiles.isNotEmpty()){
+            Text("Shared Files:", style = MaterialTheme.typography.titleMedium, modifier = Modifier.padding(top=8.dp))
+            session.sharedFiles.forEach{ file -> Text("- ${file.filename} by ${file.uploaderId} at ${file.getFormattedTimestamp()}")}
+        }
+    }
+}
+
+@Composable
+fun SessionHistoryScreen(history: List<TelemedicineSession>) {
+    Column {
+        Text("Session History", style = MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(bottom = 8.dp))
+        if (history.isEmpty()) {
+            Text("No past sessions.")
+        } else {
+            LazyColumn {
+                items(history, key = {it.sessionId}) { session ->
+                    SessionHistoryCard(session)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun SessionHistoryCard(session: TelemedicineSession) {
+    Card(Modifier.fillMaxWidth().padding(vertical = 4.dp), elevation = CardDefaults.cardElevation(2.dp)) {
+        Column(Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text("Session: ${session.sessionId.takeLast(6)} with ${session.patientName}", style = MaterialTheme.typography.titleMedium)
+            Text("Vet: ${session.vetId}, User: ${session.userId}")
+            Text("Started: ${session.getFormattedTimestamp(session.startTime)}, Ended: ${session.getFormattedTimestamp(session.endTime)}")
+            Text("Duration: ${session.durationMinutes?.let{"%.2f".format(it)} ?: "N/A"} mins, Ended By: ${session.endedBy ?: "N/A"}")
+            if(session.chatLog.isNotEmpty()) Text("Chat Messages: ${session.chatLog.size}")
+            if(session.sharedFiles.isNotEmpty()) Text("Files Shared: ${session.sharedFiles.size}")
+            if(session.sessionNotesVet.isNotBlank()) Text("Vet Notes: ${session.sessionNotesVet.take(50)}...")
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun InitiateCallDialog(viewModel: TelemedicineViewModel, onDismiss: () -> Unit) {
+    var selectedVet by remember { mutableStateOf(viewModel.knownVetIds.first()) }
+    var selectedUser by remember { mutableStateOf(viewModel.knownUserIds.first()) }
+    var patientName by remember { mutableStateOf(viewModel.patientNames.first()) }
+    var patientId by remember { mutableStateOf("pet_${Random.nextInt(100, 199)}") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Initiate New Telemedicine Call") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                ExposedDropdownMenuForOptions("Select Vet", viewModel.knownVetIds, selectedVet) { selectedVet = it }
+                ExposedDropdownMenuForOptions("Select User", viewModel.knownUserIds, selectedUser) { selectedUser = it }
+                ExposedDropdownMenuForOptions("Select Patient Name", viewModel.patientNames, patientName) { patientName = it }
+                OutlinedTextField(value = patientId, onValueChange = {patientId = it}, label = {Text("Patient ID")})
+            }
+        },
+        confirmButton = {
+            Button(onClick = {
+                viewModel.initiateCall(selectedVet, selectedUser, patientId, patientName)
+                onDismiss()
+            }) { Text("Start Call") }
+        },
+        dismissButton = { Button(onClick = onDismiss) { Text("Cancel") } }
+    )
+}
+
+// Re-using ExposedDropdownMenuForOptions, assuming it's accessible from other files in same package or shared UI
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ExposedDropdownMenuForOptions( // Copied for standalone preview if needed
+    label: String,
+    options: List<String>,
+    selectedOption: String,
+    onOptionSelected: (String) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = !expanded }
+    ) {
+        OutlinedTextField(
+            value = selectedOption,
+            onValueChange = {}, readOnly = true,
+            label = { Text(label) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier.menuAnchor().fillMaxWidth()
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            options.forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(option) },
+                    onClick = {
+                        onOptionSelected(option)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+
+@Preview(showBackground = true, heightDp = 700)
+@Composable
+fun PreviewTelemedicineScreen_NoActiveCall() {
+    MaterialTheme {
+        TelemedicineScreen(viewModel = TelemedicineViewModel())
+    }
+}
+
+@Preview(showBackground = true, heightDp = 700)
+@Composable
+fun PreviewTelemedicineScreen_ActiveCall() {
+    val viewModel = TelemedicineViewModel()
+    // Simulate an active call for preview
+    viewModel.initiateCall(viewModel.knownVetIds.first(), viewModel.knownUserIds.first(), "pet_preview", "PreviewPet")
+    // Need a slight delay or mechanism for the simulation to reach 'active' state for preview if it's async.
+    // For immediate preview, can manually set a mock active session:
+    // (viewModel as any)._activeSession.value = TelemedicineSession(...)
+    MaterialTheme {
+        TelemedicineScreen(viewModel = viewModel)
+    }
+}


### PR DESCRIPTION
Converts all specified Admin, Financials, Veterinary, and Professional Tools Python modules to Android Jetpack Compose screens with ViewModels using mock data.

Key changes include:
- UI and mock logic for all admin screens.
- UI and mock logic for all financial screens, including transaction monitoring, revenue analytics, and commission management.
- UI and mock logic for all veterinary screens, including telemedicine, prescription management, patient history, and health alerts.
- UI and mock logic for all professional tools screens, including diagnosis assistant, educational content, case studies, and veterinary networking.
- Creation of dashboard screens for Admin, Financials, Veterinary, and Professional Tools sections, each with their own internal navigation graph.
- Integration of these new sections into the main application navigation:
    - Added new routes to `NavigationRoute.kt`.
    - Added new items to `AppBottomNavigationBar.kt` for the HIGH_LEVEL user role to access these dashboards.
    - Described necessary modifications to the main `RoosterNavHost.kt` to include the new feature navigators.

This completes the primary implementation tasks based on the provided Python modules and integration requirements.